### PR TITLE
Logic internal refactor

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
@@ -94,7 +94,17 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 		}
 	}
 	
-	public abstract boolean output(int index);
+	protected abstract boolean outputInternal(int index);
+	
+	public final boolean output(int index)
+	{
+		var lock = config.getOutputLock(index);
+		if(lock != null)
+		{
+			return lock;
+		}
+		return this.outputInternal(index);
+	}
 	
 	public LogicGridSize size()
 	{
@@ -126,7 +136,12 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 		this.internalResetForPickup();
 	}
 	
-	public abstract L copy();
+	public final L copy()
+	{
+		var copy = (L) this.type().defaultFactory().create();
+		copy.loadFrom((L) this);
+		return copy;
+	}
 	
 	public abstract int hashCode();
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
@@ -13,6 +13,7 @@ import net.swedz.little_big_redstone.microchip.wire.Wire;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, LogicComponents>
 {
@@ -83,20 +84,25 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 	{
 		if(microchip.canFit(component.size().toBounds(x, y)))
 		{
-			if(component.type() == LogicTypes.DEBUGGER)
-			{
-				if(debug)
-				{
-					return null;
-				}
-				debug = true;
-			}
-			int slot = this.pickAvailableSlot();
-			var entry = new LogicEntry(slot, x, y, component);
-			objects.put(slot, entry);
-			return entry;
+			return this.addUnsafe(x, y, component);
 		}
 		return null;
+	}
+	
+	public LogicEntry addUnsafe(int x, int y, LogicComponent component)
+	{
+		if(component.type() == LogicTypes.DEBUGGER)
+		{
+			if(debug)
+			{
+				return null;
+			}
+			debug = true;
+		}
+		int slot = this.pickAvailableSlot();
+		var entry = new LogicEntry(slot, x, y, component);
+		objects.put(slot, entry);
+		return entry;
 	}
 	
 	public List<Wire> remove(int slot)
@@ -141,8 +147,13 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 	@Override
 	public void loadFrom(LogicComponents other)
 	{
+		this.loadFrom(other, (before) -> new LogicEntry(before.slot(), before.x(), before.y(), before.component()));
+	}
+	
+	public void loadFrom(LogicComponents other, Function<LogicEntry, LogicEntry> conversion)
+	{
 		Map<Integer, LogicEntry> copiedComponents = Maps.newHashMap();
-		other.objects.forEach((slot, entry) -> copiedComponents.put(slot, new LogicEntry(entry.slot(), entry.x(), entry.y(), entry.component().copy())));
+		other.objects.forEach((slot, entry) -> copiedComponents.put(slot, conversion.apply(entry)));
 		objects = copiedComponents;
 		debug = other.debug;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicContext.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicContext.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.swedz.little_big_redstone.block.microchip.MicrochipBlockEntity;
+import net.swedz.little_big_redstone.microchip.Microchip;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAwareness;
 
@@ -12,28 +13,38 @@ import java.util.List;
 
 public final class LogicContext
 {
-	private final MicrochipBlockEntity blockEntity;
+	private final Level    level;
+	private final BlockPos pos;
+	
+	private final Microchip microchip;
 	
 	private final List<LogicEntry> dirtyEntries = Lists.newArrayList();
 	
+	public LogicContext(Level level, BlockPos pos, Microchip microchip)
+	{
+		this.level = level;
+		this.pos = pos;
+		this.microchip = microchip;
+	}
+	
 	public LogicContext(MicrochipBlockEntity blockEntity)
 	{
-		this.blockEntity = blockEntity;
+		this(blockEntity.getLevel(), blockEntity.getBlockPos(), blockEntity.microchip());
 	}
 	
 	public Level level()
 	{
-		return blockEntity.getLevel();
+		return level;
 	}
 	
 	public BlockPos pos()
 	{
-		return blockEntity.getBlockPos();
+		return pos;
 	}
 	
 	public <A extends MicrochipAwareness<A>> A awareness(AwarenessType<A> type)
 	{
-		return blockEntity.microchip().awarenesses().get(type);
+		return microchip.awarenesses().get(type);
 	}
 	
 	public boolean isDirty()
@@ -43,7 +54,7 @@ public final class LogicContext
 	
 	public void markDirty(LogicComponent component)
 	{
-		for(var entry : blockEntity.microchip().components())
+		for(var entry : microchip.components())
 		{
 			if(entry.component() == component && !dirtyEntries.contains(entry))
 			{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/LogicConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/LogicConfig.java
@@ -4,11 +4,28 @@ import net.minecraft.network.chat.Component;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponents;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicPortHolder;
 
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class LogicConfig<C extends LogicConfig<C>> implements LogicPortHolder
 {
 	protected boolean valid = true;
+	
+	/**
+	 * Used to lock signals on or off in the guide.
+	 * <br><br>
+	 * <b>WARNING: Should not be used at all outside of the guide. Ever. If this is not null for a logic component
+	 * outside of the guide, something has gone terribly wrong.</b>
+	 */
+	protected Boolean[] outputLocks;
+	
+	/**
+	 * Used to hide logic in the guide so that only the wires to/from it render.
+	 * <br><br>
+	 * <b>WARNING: Should not be used at all outside the guide. Ever. If this is not false for a logic component
+	 * outside of the guide, something has gone terribly wrong.</b>
+	 */
+	protected boolean hidden = false;
 	
 	public final boolean isValid()
 	{
@@ -25,6 +42,30 @@ public abstract class LogicConfig<C extends LogicConfig<C>> implements LogicPort
 		return true;
 	}
 	
+	public final void setOutputLock(int index, Boolean lock)
+	{
+		if(outputLocks == null || outputLocks.length <= index)
+		{
+			outputLocks = outputLocks == null ? new Boolean[index + 1] : Arrays.copyOf(outputLocks, index + 1);
+		}
+		outputLocks[index] = lock;
+	}
+	
+	public final Boolean getOutputLock(int index)
+	{
+		return (outputLocks == null || outputLocks.length <= index) ? null : outputLocks[index];
+	}
+	
+	public final void hide()
+	{
+		hidden = true;
+	}
+	
+	public final boolean isVisible()
+	{
+		return !hidden;
+	}
+	
 	public void appendHoverText(List<Component> lines)
 	{
 	}
@@ -38,11 +79,17 @@ public abstract class LogicConfig<C extends LogicConfig<C>> implements LogicPort
 	{
 	}
 	
-	public abstract void loadFrom(C other);
+	protected abstract void internalLoadFrom(C other);
+	
+	public final void loadFrom(C other)
+	{
+		valid = other.valid;
+		outputLocks = other.outputLocks;
+		hidden = other.hidden;
+		this.internalLoadFrom(other);
+	}
 	
 	public abstract void resetForPickup();
-	
-	public abstract C copy();
 	
 	public abstract int hashCode();
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
@@ -40,7 +40,7 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	@Override
 	protected LogicDebuggerConfig defaultConfig()
 	{
-		return LogicDebuggerConfig.INSTANCE;
+		return new LogicDebuggerConfig();
 	}
 	
 	@Override
@@ -55,7 +55,7 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return false;
 	}
@@ -68,12 +68,6 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	@Override
 	protected void internalResetForPickup()
 	{
-	}
-	
-	@Override
-	public LogicDebugger copy()
-	{
-		return new LogicDebugger(color);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
@@ -5,14 +5,12 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 public final class LogicDebuggerConfig extends LogicConfig<LogicDebuggerConfig>
 {
-	public static final LogicDebuggerConfig INSTANCE = new LogicDebuggerConfig();
-	
-	private LogicDebuggerConfig()
+	public LogicDebuggerConfig()
 	{
 	}
 	
 	@Override
-	public void loadFrom(LogicDebuggerConfig other)
+	protected void internalLoadFrom(LogicDebuggerConfig other)
 	{
 	}
 	
@@ -43,12 +41,6 @@ public final class LogicDebuggerConfig extends LogicConfig<LogicDebuggerConfig>
 	public int outputs()
 	{
 		return 0;
-	}
-	
-	@Override
-	public LogicDebuggerConfig copy()
-	{
-		return this;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
@@ -76,12 +76,6 @@ public final class ANDGate extends LogicGate<ANDGate, MultiLogicGateConfig>
 	}
 	
 	@Override
-	public ANDGate copy()
-	{
-		return new ANDGate(config.copy(), color, this.output());
-	}
-	
-	@Override
 	public int hashCode()
 	{
 		return Objects.hash(this.type(), config, color);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
@@ -24,7 +24,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 				.group(
 						configCodec.fieldOf("config").forGetter(LogicComponent::config),
 						DyeColor.CODEC.optionalFieldOf("color").forGetter(LogicComponent::color),
-						Codec.BOOL.fieldOf("output").forGetter(LogicGate::output)
+						Codec.BOOL.optionalFieldOf("output", false).forGetter(LogicGate::output)
 				)
 				.apply(instance, function));
 	}
@@ -34,7 +34,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 		return RecordCodecBuilder.mapCodec((instance) -> instance
 				.group(
 						DyeColor.CODEC.optionalFieldOf("color").forGetter(LogicComponent::color),
-						Codec.BOOL.fieldOf("output").forGetter(LogicGate::output)
+						Codec.BOOL.optionalFieldOf("output", false).forGetter(LogicGate::output)
 				)
 				.apply(instance, creator));
 	}
@@ -86,14 +86,14 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 	}
 	
 	@Override
-	public final boolean output(int index)
+	protected final boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public final boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -106,7 +106,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 	@Override
 	protected void internalLoadFrom(G other)
 	{
-		outputState = other.output();
+		outputState = other.outputInternal(0);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
@@ -76,12 +76,6 @@ public final class NANDGate extends LogicGate<NANDGate, MultiLogicGateConfig>
 	}
 	
 	@Override
-	public NANDGate copy()
-	{
-		return new NANDGate(config.copy(), color, this.output());
-	}
-	
-	@Override
 	public int hashCode()
 	{
 		return Objects.hash(this.type(), config, color);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
@@ -76,12 +76,6 @@ public final class NORGate extends LogicGate<NORGate, MultiLogicGateConfig>
 	}
 	
 	@Override
-	public NORGate copy()
-	{
-		return new NORGate(config.copy(), color, this.output());
-	}
-	
-	@Override
 	public int hashCode()
 	{
 		return Objects.hash(this.type(), config, color);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
@@ -36,7 +36,7 @@ public final class NOTGate extends LogicGate<NOTGate, SingleLogicGateConfig>
 	@Override
 	protected SingleLogicGateConfig defaultConfig()
 	{
-		return SingleLogicGateConfig.INSTANCE;
+		return new SingleLogicGateConfig();
 	}
 	
 	@Override
@@ -61,12 +61,6 @@ public final class NOTGate extends LogicGate<NOTGate, SingleLogicGateConfig>
 	public void appendShiftHoverText(List<Component> lines)
 	{
 		lines.add(line(LBRText.LOGIC_HELP_NOT_GATE));
-	}
-	
-	@Override
-	public NOTGate copy()
-	{
-		return new NOTGate(color, this.output());
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
@@ -76,12 +76,6 @@ public final class ORGate extends LogicGate<ORGate, MultiLogicGateConfig>
 	}
 	
 	@Override
-	public ORGate copy()
-	{
-		return new ORGate(config.copy(), color, this.output());
-	}
-	
-	@Override
 	public int hashCode()
 	{
 		return Objects.hash(this.type(), config, color);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
@@ -77,12 +77,6 @@ public final class XORGate extends LogicGate<XORGate, MultiLogicGateConfig>
 	}
 	
 	@Override
-	public XORGate copy()
-	{
-		return new XORGate(config.copy(), color, this.output());
-	}
-	
-	@Override
 	public int hashCode()
 	{
 		return Objects.hash(this.type(), config, color);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
@@ -84,7 +84,7 @@ public final class MultiLogicGateConfig extends LogicConfig<MultiLogicGateConfig
 	}
 	
 	@Override
-	public void loadFrom(MultiLogicGateConfig other)
+	protected void internalLoadFrom(MultiLogicGateConfig other)
 	{
 		inputs = this.inputsAllowed().clamp(other.inputs);
 	}
@@ -92,12 +92,6 @@ public final class MultiLogicGateConfig extends LogicConfig<MultiLogicGateConfig
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public MultiLogicGateConfig copy()
-	{
-		return new MultiLogicGateConfig(inputs);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
@@ -5,9 +5,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 public final class SingleLogicGateConfig extends LogicConfig<SingleLogicGateConfig>
 {
-	public static final SingleLogicGateConfig INSTANCE = new SingleLogicGateConfig();
-	
-	private SingleLogicGateConfig()
+	public SingleLogicGateConfig()
 	{
 	}
 	
@@ -36,19 +34,13 @@ public final class SingleLogicGateConfig extends LogicConfig<SingleLogicGateConf
 	}
 	
 	@Override
-	public void loadFrom(SingleLogicGateConfig other)
+	protected void internalLoadFrom(SingleLogicGateConfig other)
 	{
 	}
 	
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public SingleLogicGateConfig copy()
-	{
-		return this;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
@@ -106,14 +106,14 @@ public final class LogicIO extends LogicComponent<LogicIO, LogicIOConfig> implem
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -133,12 +133,6 @@ public final class LogicIO extends LogicComponent<LogicIO, LogicIOConfig> implem
 	public void internalResetForPickup()
 	{
 		outputState = false;
-	}
-	
-	@Override
-	public LogicIO copy()
-	{
-		return new LogicIO(config.copy(), color, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
@@ -131,7 +131,7 @@ public final class LogicIOConfig extends LogicConfig<LogicIOConfig>
 	}
 	
 	@Override
-	public void loadFrom(LogicIOConfig other)
+	protected void internalLoadFrom(LogicIOConfig other)
 	{
 		input = other.input;
 		direction = other.direction;
@@ -142,12 +142,6 @@ public final class LogicIOConfig extends LogicConfig<LogicIOConfig>
 	public void resetForPickup()
 	{
 		valid = true;
-	}
-	
-	@Override
-	public LogicIOConfig copy()
-	{
-		return new LogicIOConfig(valid, input, direction, signalStrength);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
@@ -51,7 +51,7 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	@Override
 	protected RSNORLatchConfig defaultConfig()
 	{
-		return RSNORLatchConfig.INSTANCE;
+		return new RSNORLatchConfig();
 	}
 	
 	@Override
@@ -83,14 +83,14 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -110,12 +110,6 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	protected void internalResetForPickup()
 	{
 		outputState = false;
-	}
-	
-	@Override
-	public RSNORLatch copy()
-	{
-		return new RSNORLatch(color, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
@@ -5,9 +5,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 public final class RSNORLatchConfig extends LogicConfig<RSNORLatchConfig>
 {
-	public static final RSNORLatchConfig INSTANCE = new RSNORLatchConfig();
-	
-	private RSNORLatchConfig()
+	public RSNORLatchConfig()
 	{
 	}
 	
@@ -36,19 +34,13 @@ public final class RSNORLatchConfig extends LogicConfig<RSNORLatchConfig>
 	}
 	
 	@Override
-	public void loadFrom(RSNORLatchConfig other)
+	protected void internalLoadFrom(RSNORLatchConfig other)
 	{
 	}
 	
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public RSNORLatchConfig copy()
-	{
-		return this;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
@@ -54,7 +54,7 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	@Override
 	protected TFlipFlopConfig defaultConfig()
 	{
-		return TFlipFlopConfig.INSTANCE;
+		return new TFlipFlopConfig();
 	}
 	
 	@Override
@@ -83,14 +83,14 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -111,12 +111,6 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	{
 		lastInputState = false;
 		outputState = false;
-	}
-	
-	@Override
-	public TFlipFlop copy()
-	{
-		return new TFlipFlop(color, lastInputState, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
@@ -5,9 +5,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 public final class TFlipFlopConfig extends LogicConfig<TFlipFlopConfig>
 {
-	public static final TFlipFlopConfig INSTANCE = new TFlipFlopConfig();
-	
-	private TFlipFlopConfig()
+	public TFlipFlopConfig()
 	{
 	}
 	
@@ -36,19 +34,13 @@ public final class TFlipFlopConfig extends LogicConfig<TFlipFlopConfig>
 	}
 	
 	@Override
-	public void loadFrom(TFlipFlopConfig other)
+	protected void internalLoadFrom(TFlipFlopConfig other)
 	{
 	}
 	
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public TFlipFlopConfig copy()
-	{
-		return this;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
@@ -125,14 +125,14 @@ public final class PulseThrottler extends LogicComponent<PulseThrottler, PulseTh
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -155,12 +155,6 @@ public final class PulseThrottler extends LogicComponent<PulseThrottler, PulseTh
 		lastInputState = false;
 		processedTicks = 0;
 		outputState = false;
-	}
-	
-	@Override
-	public PulseThrottler copy()
-	{
-		return new PulseThrottler(config.copy(), color, lastInputState, processedTicks, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
@@ -86,7 +86,7 @@ public final class PulseThrottlerConfig extends LogicConfig<PulseThrottlerConfig
 	}
 	
 	@Override
-	public void loadFrom(PulseThrottlerConfig other)
+	protected void internalLoadFrom(PulseThrottlerConfig other)
 	{
 		outputDuration = other.outputDuration;
 	}
@@ -94,12 +94,6 @@ public final class PulseThrottlerConfig extends LogicConfig<PulseThrottlerConfig
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public PulseThrottlerConfig copy()
-	{
-		return new PulseThrottlerConfig(outputDuration);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
@@ -8,6 +8,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRText;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
@@ -23,6 +24,8 @@ import static net.swedz.little_big_redstone.LBRTextLine.*;
 
 public final class LogicRandomizer extends LogicComponent<LogicRandomizer, LogicRandomizerConfig>
 {
+	private static final RandomSource RANDOM = RandomSource.create();
+	
 	public static final MapCodec<LogicRandomizer> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
 					LogicRandomizerConfig.CODEC.fieldOf("config").forGetter(LogicRandomizer::config),
@@ -67,9 +70,9 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	{
 		int originalOutputIndex = outputIndex;
 		
-		if(inputs[0] && context.level().random.nextFloat() <= config.chance)
+		if(inputs[0] && RANDOM.nextFloat() <= config.chance)
 		{
-			outputIndex = context.level().random.nextInt(config.outputs);
+			outputIndex = RANDOM.nextInt(config.outputs);
 		}
 		else
 		{
@@ -83,7 +86,7 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return index == outputIndex;
 	}
@@ -111,12 +114,6 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	protected void internalResetForPickup()
 	{
 		outputIndex = -1;
-	}
-	
-	@Override
-	public LogicRandomizer copy()
-	{
-		return new LogicRandomizer(config.copy(), color, outputIndex);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
@@ -71,7 +71,7 @@ public final class LogicRandomizerConfig extends LogicConfig<LogicRandomizerConf
 	}
 	
 	@Override
-	public void loadFrom(LogicRandomizerConfig other)
+	protected void internalLoadFrom(LogicRandomizerConfig other)
 	{
 		outputs = other.outputs;
 		chance = other.chance;
@@ -80,12 +80,6 @@ public final class LogicRandomizerConfig extends LogicConfig<LogicRandomizerConf
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public LogicRandomizerConfig copy()
-	{
-		return new LogicRandomizerConfig(outputs, chance);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRText;
@@ -84,57 +85,60 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 		
 		float fill = 0;
 		
-		if(config.mode == LogicReaderMode.ITEM)
+		if(context.level() instanceof ServerLevel)
 		{
-			var awareness = context.awareness(AwarenessTypes.CAPABILITY_ITEM);
-			var handler = awareness.get(context.level(), context.pos(), config.direction);
-			if(handler != null)
+			if(config.mode == LogicReaderMode.ITEM)
 			{
-				int totalItems = 0;
-				int maxItems = 0;
-				for(int slot = 0; slot < handler.getSlots(); slot++)
+				var awareness = context.awareness(AwarenessTypes.CAPABILITY_ITEM);
+				var handler = awareness.get(context.level(), context.pos(), config.direction);
+				if(handler != null)
 				{
-					var stack = handler.getStackInSlot(slot);
-					if(stack.isEmpty())
+					int totalItems = 0;
+					int maxItems = 0;
+					for(int slot = 0; slot < handler.getSlots(); slot++)
 					{
-						maxItems += Mth.clamp(handler.getSlotLimit(slot), 0, 64);
+						var stack = handler.getStackInSlot(slot);
+						if(stack.isEmpty())
+						{
+							maxItems += Mth.clamp(handler.getSlotLimit(slot), 0, 64);
+						}
+						else
+						{
+							totalItems += stack.getCount();
+							maxItems += stack.getMaxStackSize();
+						}
 					}
-					else
-					{
-						totalItems += stack.getCount();
-						maxItems += stack.getMaxStackSize();
-					}
+					fill = (float) totalItems / maxItems;
 				}
-				fill = (float) totalItems / maxItems;
 			}
-		}
-		
-		else if(config.mode == LogicReaderMode.FLUID)
-		{
-			var awareness = context.awareness(AwarenessTypes.CAPABILITY_FLUID);
-			var handler = awareness.get(context.level(), context.pos(), config.direction);
-			if(handler != null)
+			
+			else if(config.mode == LogicReaderMode.FLUID)
 			{
-				int totalFluid = 0;
-				int maxFluid = 0;
-				for(int tank = 0; tank < handler.getTanks(); tank++)
+				var awareness = context.awareness(AwarenessTypes.CAPABILITY_FLUID);
+				var handler = awareness.get(context.level(), context.pos(), config.direction);
+				if(handler != null)
 				{
-					totalFluid += handler.getFluidInTank(tank).getAmount();
-					maxFluid += handler.getTankCapacity(tank);
+					int totalFluid = 0;
+					int maxFluid = 0;
+					for(int tank = 0; tank < handler.getTanks(); tank++)
+					{
+						totalFluid += handler.getFluidInTank(tank).getAmount();
+						maxFluid += handler.getTankCapacity(tank);
+					}
+					fill = (float) totalFluid / maxFluid;
 				}
-				fill = (float) totalFluid / maxFluid;
 			}
-		}
-		
-		else if(config.mode == LogicReaderMode.ENERGY)
-		{
-			var awareness = context.awareness(AwarenessTypes.CAPABILITY_ENERGY);
-			var handler = awareness.get(context.level(), context.pos(), config.direction);
-			if(handler != null)
+			
+			else if(config.mode == LogicReaderMode.ENERGY)
 			{
-				int totalEnergy = handler.getEnergyStored();
-				int maxEnergy = handler.getMaxEnergyStored();
-				fill = (float) totalEnergy / maxEnergy;
+				var awareness = context.awareness(AwarenessTypes.CAPABILITY_ENERGY);
+				var handler = awareness.get(context.level(), context.pos(), config.direction);
+				if(handler != null)
+				{
+					int totalEnergy = handler.getEnergyStored();
+					int maxEnergy = handler.getMaxEnergyStored();
+					fill = (float) totalEnergy / maxEnergy;
+				}
 			}
 		}
 		
@@ -152,14 +156,14 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -179,12 +183,6 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 	public void internalResetForPickup()
 	{
 		outputState = false;
-	}
-	
-	@Override
-	public LogicReader copy()
-	{
-		return new LogicReader(config.copy(), color, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
@@ -107,7 +107,7 @@ public final class LogicReaderConfig extends LogicConfig<LogicReaderConfig>
 	}
 	
 	@Override
-	public void loadFrom(LogicReaderConfig other)
+	protected void internalLoadFrom(LogicReaderConfig other)
 	{
 		mode = other.mode;
 		direction = other.direction;
@@ -117,12 +117,6 @@ public final class LogicReaderConfig extends LogicConfig<LogicReaderConfig>
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public LogicReaderConfig copy()
-	{
-		return new LogicReaderConfig(mode, direction, fillThreshold);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
@@ -109,7 +109,7 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return index == selected;
 	}
@@ -137,12 +137,6 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 	protected void internalResetForPickup()
 	{
 		selected = 0;
-	}
-	
-	@Override
-	public LogicSelector copy()
-	{
-		return new LogicSelector(config.copy(), color, selected);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
@@ -80,7 +80,7 @@ public final class LogicSelectorConfig extends LogicConfig<LogicSelectorConfig>
 	}
 	
 	@Override
-	public void loadFrom(LogicSelectorConfig other)
+	protected void internalLoadFrom(LogicSelectorConfig other)
 	{
 		mode = other.mode;
 		outputs = other.outputs;
@@ -89,12 +89,6 @@ public final class LogicSelectorConfig extends LogicConfig<LogicSelectorConfig>
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public LogicSelectorConfig copy()
-	{
-		return new LogicSelectorConfig(mode, outputs);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
@@ -130,14 +130,14 @@ public final class LogicSequencer extends LogicComponent<LogicSequencer, LogicSe
 	}
 	
 	@Override
-	public boolean output(int index)
+	protected boolean outputInternal(int index)
 	{
 		return outputState;
 	}
 	
 	public boolean output()
 	{
-		return outputState;
+		return this.output(0);
 	}
 	
 	@Override
@@ -166,12 +166,6 @@ public final class LogicSequencer extends LogicComponent<LogicSequencer, LogicSe
 	{
 		processedTicks = 0;
 		outputState = false;
-	}
-	
-	@Override
-	public LogicSequencer copy()
-	{
-		return new LogicSequencer(config.copy(), color, processedTicks, outputState);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
@@ -119,7 +119,7 @@ public final class LogicSequencerConfig extends LogicConfig<LogicSequencerConfig
 	}
 	
 	@Override
-	public void loadFrom(LogicSequencerConfig other)
+	protected void internalLoadFrom(LogicSequencerConfig other)
 	{
 		mode = other.mode;
 		outputDelay = other.outputDelay;
@@ -130,12 +130,6 @@ public final class LogicSequencerConfig extends LogicConfig<LogicSequencerConfig
 	@Override
 	public void resetForPickup()
 	{
-	}
-	
-	@Override
-	public LogicSequencerConfig copy()
-	{
-		return new LogicSequencerConfig(mode, outputDelay, autoReset, resetPort);
 	}
 	
 	@Override


### PR DESCRIPTION
Cleans up a few things with the logic internals:

- `copy()` method is removed from `LogicConfig`
- `copy()` method is now implemented directly in `LogicComponent` instead of each implementation
- Allow a transformation to be applied to logic when calling `LogicComponent#loadFrom`
- `LogicContext` doesn't require a block entity
- `loadFrom()` method is now implemented inside `LogicConfig` and uses `internalLoadFrom()` to copy implementation fields
- `LogicGate` codecs to have `output` be optional
- Every logic component will have its own config instance rather than some using singleton config instances. This avoids any possible issues of the innate config fields being modified on these components
- Randomizer uses its own independent `RandomSource` rather than the `Level`'s because it can be null now
- Reader accounts for nullable `Level`