### PR TITLE
Fix #29: Crash when updating Microchip from a non adjacent block

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/block/microchip/MicrochipBlock.java
+++ b/src/main/java/net/swedz/little_big_redstone/block/microchip/MicrochipBlock.java
@@ -128,7 +128,10 @@ public final class MicrochipBlock extends Block implements TickableBlock, DyeCol
 		
 		var delta = neighborPos.subtract(pos);
 		Direction neighborDirection = Direction.fromDelta(delta.getX(), delta.getY(), delta.getZ());
-		blockEntity.microchip().awarenesses().neighborChanged(new AwarenessContext(blockEntity), neighborBlock, neighborPos, neighborDirection, movedByPiston);
+		if(neighborDirection != null)
+		{
+			blockEntity.microchip().awarenesses().neighborChanged(new AwarenessContext(blockEntity), neighborBlock, neighborPos, neighborDirection, movedByPiston);
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
I never had this come up in testing, but it only happens when Alternate Current is installed. For now just ignoring the non-adjacent updates is fine because we only care about the adjacent signals anyway...