### PR TITLE
Fix #28: Circuit diagrams in GuideME pages don't display on certain UI scales

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
+++ b/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
@@ -363,7 +363,7 @@ public final class MicrochipGuidebookScene extends LytBox implements ExportableR
 			
 			context.renderPanel(bounds);
 			
-			graphics.pose().translate(bounds.x() + PANEL_MARGIN, bounds.y() + PANEL_MARGIN, 0);
+			graphics.pose().translate(bounds.x() + PANEL_MARGIN, bounds.y() + PANEL_MARGIN, 10);
 			
 			panel.render(graphics);
 			


### PR DESCRIPTION
Seems to only happen on MacOS, which is odd. I believe this is just a combination of how GuideME makes its screen GUI scale independent and how OpenGL differs somewhat when running on MacOS.