### PR TITLE
Fix logic scanline scale when in item form

### DIFF
--- a/src/main/resources/assets/little_big_redstone/shaders/core/logic_item_scanline.fsh
+++ b/src/main/resources/assets/little_big_redstone/shaders/core/logic_item_scanline.fsh
@@ -25,7 +25,7 @@ vec2 transformScanlineUV(vec2 uv)
 	vec2 motion = vec2(0, 150.0 / 32.0);
 	vec2 translation = vec2(GameTime) * motion;
 	transformedUV += translation;
-	transformedUV *= 256.0;
+	transformedUV *= 512.0;
 	return fract(transformedUV);
 }
 


### PR DESCRIPTION
For some reason the scanlines were twice as big when the logic was in item form (in your inventory, as opposed to in the Microchip gui).

This worked fine at one point but randomly broke at some point. If this comes up again there's definitely something more serious going on.