### PR TITLE
Increase logic gate limit

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
@@ -88,7 +88,7 @@ public final class LogicTypes
 			LogicFactory defaultFactory
 	)
 	{
-		var type = new LogicType<>(id, englishName, Character.forDigit(SYMBOL.getAndIncrement(), 16), codec, streamCodec, defaultFactory);
+		var type = new LogicType<>(id, englishName, Character.forDigit(SYMBOL.getAndIncrement(), 36), codec, streamCodec, defaultFactory);
 		LOGICS.add(type);
 		LOGICS_MAP.put(id, type);
 		return type;


### PR DESCRIPTION
Max radix for Character.forDigit is 36, why limit to 16?
Anyway it's a hacky workaround to add more gates.