### PR TITLE
Fix possible rare deadlocks when unloading a microchip

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/awareness/types/RedstoneAwareness.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/awareness/types/RedstoneAwareness.java
@@ -150,6 +150,10 @@ public final class RedstoneAwareness extends MicrochipAwareness<RedstoneAwarenes
 		{
 			var level = context.level();
 			var pos = context.blockPos();
+			if(!level.isLoaded(pos))
+			{
+				return;
+			}
 			var state = context.state();
 			this.sendUpdates(level, pos, state, state, removedSides, removedStrongSides);
 		}


### PR DESCRIPTION
I'm not 100% sure this was the problem, but it seems like this fixes it?