### PR TITLE
Require sneak + click to dye or seal sticky notes

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/entity/stickynote/StickyNoteEntity.java
+++ b/src/main/java/net/swedz/little_big_redstone/entity/stickynote/StickyNoteEntity.java
@@ -368,49 +368,52 @@ public final class StickyNoteEntity extends HangingEntity
 			var stack = player.getItemInHand(hand);
 			if(this.isEditable())
 			{
-				if(stack.getItem() instanceof DyeItem dyeItem &&
-				   dyeItem.getDyeColor() != this.getTextColor())
+				if(player.isShiftKeyDown())
 				{
-					player.awardStat(Stats.ITEM_USED.get(stack.getItem()));
-					this.playSound(SoundEvents.DYE_USE);
-					this.setTextColor(dyeItem.getDyeColor());
-					stack.consume(1, player);
-					return InteractionResult.CONSUME;
-				}
-				else if(stack.is(LBRTags.Items.DYE_WASHER))
-				{
-					var defaultTextColor = StickyNoteItem.getDefaultTextColor(this.getColor());
-					if(this.getTextColor() != defaultTextColor)
+					if(stack.getItem() instanceof DyeItem dyeItem &&
+					   dyeItem.getDyeColor() != this.getTextColor())
 					{
 						player.awardStat(Stats.ITEM_USED.get(stack.getItem()));
-						this.playSound(SoundEvents.BUCKET_EMPTY);
-						this.setTextColor(defaultTextColor);
-						if(stack.is(LBRTags.Items.DYE_WASHER_CONSUMED))
+						this.playSound(SoundEvents.DYE_USE);
+						this.setTextColor(dyeItem.getDyeColor());
+						stack.consume(1, player);
+						return InteractionResult.CONSUME;
+					}
+					else if(stack.is(LBRTags.Items.DYE_WASHER))
+					{
+						var defaultTextColor = StickyNoteItem.getDefaultTextColor(this.getColor());
+						if(this.getTextColor() != defaultTextColor)
 						{
-							stack.consume(1, player);
+							player.awardStat(Stats.ITEM_USED.get(stack.getItem()));
+							this.playSound(SoundEvents.BUCKET_EMPTY);
+							this.setTextColor(defaultTextColor);
+							if(stack.is(LBRTags.Items.DYE_WASHER_CONSUMED))
+							{
+								stack.consume(1, player);
+							}
+							return InteractionResult.CONSUME;
 						}
+					}
+					else if(stack.is(LBRTags.Items.STICKY_NOTE_SEALANT))
+					{
+						this.setEditable(false);
+						this.level().playSound(null, this.blockPosition(), SoundEvents.HONEYCOMB_WAX_ON, SoundSource.BLOCKS);
+						((ServerLevel) this.level()).sendParticles(
+								ParticleTypes.WAX_ON,
+								this.getX(),
+								this.getY(),
+								this.getZ(),
+								6,
+								0.125,
+								0.125,
+								0.125,
+								Mth.nextDouble(random, -0.5f, 0.5f)
+						);
+						stack.consume(1, player);
 						return InteractionResult.CONSUME;
 					}
 				}
-				else if(stack.is(LBRTags.Items.STICKY_NOTE_SEALANT))
-				{
-					this.setEditable(false);
-					this.level().playSound(null, this.blockPosition(), SoundEvents.HONEYCOMB_WAX_ON, SoundSource.BLOCKS);
-					((ServerLevel) this.level()).sendParticles(
-							ParticleTypes.WAX_ON,
-							this.getX(),
-							this.getY(),
-							this.getZ(),
-							6,
-							0.125,
-							0.125,
-							0.125,
-							Mth.nextDouble(random, -0.5f, 0.5f)
-					);
-					stack.consume(1, player);
-					return InteractionResult.CONSUME;
-				}
-				else if(!stack.isEmpty())
+				if(!stack.isEmpty())
 				{
 					this.setDisplayItem(stack.copy());
 					this.level().playSound(null, this.blockPosition(), SoundEvents.ITEM_FRAME_ADD_ITEM, SoundSource.BLOCKS);

--- a/src/main/resources/assets/little_big_redstone/guide/sticky_notes.md
+++ b/src/main/resources/assets/little_big_redstone/guide/sticky_notes.md
@@ -102,8 +102,8 @@ contents and colors when broken and placed.
 Text lines will only appear on the sticky notes in-world when text is written on them.
 
 Sticky notes can be sealed using Honeycomb, much like signs. A sealed sticky note can no longer be edited. This can be
-done either through crafting a sticky note with a Honeycomb, or by using **<KeyBind id="key.use" />** on a sticky note
-placed in world with a Honeycomb.
+done either through crafting a sticky note with a Honeycomb, or by using **<KeyBind id="key.sneak" />** and
+**<KeyBind id="key.use" />** on a sticky note placed in world with a Honeycomb.
 
 ### Markdown
 
@@ -127,7 +127,8 @@ boxes by putting \[ \] or \[x\] after the space after the bullet point symbol. F
 
 ### Coloring
 
-The text on sticky notes can be colored by pressing **<KeyBind id="key.use" />** with dye.
+The text on sticky notes can be colored by pressing **<KeyBind id="key.sneak" />** and **<KeyBind id="key.use" />**
+with dye.
 
 Similarly, you can use a water bucket or snowballs to clear the color from the logic component. Note that snowballs
 will be consumed, whereas water buckets will not.


### PR DESCRIPTION
Avoids situations where you want to place a dye or sealant into the display of the sticky note but it dyes or seals it instead