### PR TITLE
Fix unable to load microchip programs with sticky notes

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/note/StickyNoteEntry.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/note/StickyNoteEntry.java
@@ -29,7 +29,7 @@ public final class StickyNoteEntry implements MicrochipObject
 					DyeColor.CODEC.fieldOf("color").forGetter(StickyNoteEntry::noteColor),
 					StickyNote.CODEC.fieldOf("note").forGetter(StickyNoteEntry::note),
 					DyeColor.CODEC.fieldOf("text_color").forGetter(StickyNoteEntry::textColor),
-					Codec.BOOL.fieldOf("editable").forGetter(StickyNoteEntry::isEditable)
+					Codec.BOOL.optionalFieldOf("editable", true).forGetter(StickyNoteEntry::isEditable)
 			)
 			.apply(instance, StickyNoteEntry::new));
 	


### PR DESCRIPTION
Forgot to make the editable field in the codec optional