### PR TITLE
Use components for item colors

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/LBRBlocks.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRBlocks.java
@@ -138,7 +138,10 @@ public final class LBRBlocks
 								.texture("base_down", LBR.id("block/microchip/bottom/%s".formatted(colorId)))
 								.texture("signal_on_overlay", LBR.id("block/microchip/signal_on_overlay"))
 								.texture("signal_off_overlay", LBR.id("block/microchip/signal_off_overlay"))));
-		holder.item().tag(LBRTags.Items.MICROCHIPS);
+		holder.item()
+				.withProperties((p) -> p
+						.component(LBRComponents.MICROCHIP_COLOR, color))
+				.tag(LBRTags.Items.MICROCHIPS);
 		return holder;
 	}
 }

--- a/src/main/java/net/swedz/little_big_redstone/LBRClient.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRClient.java
@@ -112,7 +112,8 @@ public final class LBRClient
 	@SubscribeEvent
 	private static void renderHand(RenderHandEvent event)
 	{
-		if(event.getItemStack().getItem() instanceof StickyNoteItem)
+		if(event.getItemStack().getItem() instanceof StickyNoteItem &&
+		   StickyNoteItem.hasRelevantComponents(event.getItemStack()))
 		{
 			StickyNoteInHandItemRenderer.renderItemFirstPerson(
 					event.getPoseStack(),

--- a/src/main/java/net/swedz/little_big_redstone/LBRComponents.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRComponents.java
@@ -36,16 +36,24 @@ public final class LBRComponents
 	 * @see LogicItem#verifyComponentsAfterLoad(ItemStack)
 	 */
 	@Deprecated(since = "1.8.3-beta", forRemoval = true)
-	public static final Supplier<DataComponentType<LogicComponent>>        LOGIC                    = create("logic", LogicCodecs.COMPONENT_CODEC, LogicCodecs.COMPONENT_STREAM_CODEC);
-	public static final Supplier<DataComponentType<LogicConfig>>           LOGIC_CONFIG             = create("logic_config", LogicCodecs.CONFIG_CODEC, LogicCodecs.CONFIG_STREAM_CODEC);
-	public static final Supplier<DataComponentType<DyeColor>>              LOGIC_COLOR              = create("logic_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
-	public static final Supplier<DataComponentType<ItemContainerContents>> LOGIC_ARRAY_STORAGE      = create("logic_array_storage", ItemContainerContents.CODEC, ItemContainerContents.STREAM_CODEC);
+	public static final Supplier<DataComponentType<LogicComponent>> LOGIC        = create("logic", LogicCodecs.COMPONENT_CODEC, LogicCodecs.COMPONENT_STREAM_CODEC);
+	public static final Supplier<DataComponentType<LogicConfig>>    LOGIC_CONFIG = create("logic_config", LogicCodecs.CONFIG_CODEC, LogicCodecs.CONFIG_STREAM_CODEC);
+	public static final Supplier<DataComponentType<DyeColor>>       LOGIC_COLOR  = create("logic_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
+	
+	public static final Supplier<DataComponentType<DyeColor>> MICROCHIP_COLOR = create("microchip_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
+	
+	public static final Supplier<DataComponentType<DyeColor>>              LOGIC_ARRAY_COLOR   = create("logic_array_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
+	public static final Supplier<DataComponentType<ItemContainerContents>> LOGIC_ARRAY_STORAGE = create("logic_array_storage", ItemContainerContents.CODEC, ItemContainerContents.STREAM_CODEC);
+	
+	public static final Supplier<DataComponentType<DyeColor>>              FLOPPY_DISK_COLOR        = create("floppy_disk_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
 	public static final Supplier<DataComponentType<Microchip.Immutable>>   FLOPPY_DISK              = create("floppy_disk", Microchip.Immutable.CODEC, Microchip.Immutable.STREAM_CODEC);
 	public static final Supplier<DataComponentType<FloppyDiskProgramName>> FLOPPY_DISK_PROGRAM_NAME = create("floppy_disk_program_name", FloppyDiskProgramName.CODEC, FloppyDiskProgramName.STREAM_CODEC);
-	public static final Supplier<DataComponentType<StickyNote>>            STICKY_NOTE              = create("sticky_note", StickyNote.CODEC, StickyNote.STREAM_CODEC);
-	public static final Supplier<DataComponentType<DyeColor>>              STICKY_NOTE_TEXT_COLOR   = create("sticky_note_text_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
-	public static final Supplier<DataComponentType<Boolean>>               STICKY_NOTE_EDITABLE     = create("sticky_note_editable", Codec.BOOL, ByteBufCodecs.BOOL);
-	public static final Supplier<DataComponentType<ItemInstance>>          STICKY_NOTE_DISPLAY_ITEM = create("sticky_note_display_item", ItemInstance.CODEC, ItemInstance.STREAM_CODEC);
+	
+	public static final Supplier<DataComponentType<StickyNote>>   STICKY_NOTE              = create("sticky_note", StickyNote.CODEC, StickyNote.STREAM_CODEC);
+	public static final Supplier<DataComponentType<DyeColor>>     STICKY_NOTE_COLOR        = create("sticky_note_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
+	public static final Supplier<DataComponentType<DyeColor>>     STICKY_NOTE_TEXT_COLOR   = create("sticky_note_text_color", DyeColor.CODEC, DyeColor.STREAM_CODEC);
+	public static final Supplier<DataComponentType<Boolean>>      STICKY_NOTE_EDITABLE     = create("sticky_note_editable", Codec.BOOL, ByteBufCodecs.BOOL);
+	public static final Supplier<DataComponentType<ItemInstance>> STICKY_NOTE_DISPLAY_ITEM = create("sticky_note_display_item", ItemInstance.CODEC, ItemInstance.STREAM_CODEC);
 	
 	public static void init(IEventBus bus)
 	{

--- a/src/main/java/net/swedz/little_big_redstone/block/microchip/MicrochipBlock.java
+++ b/src/main/java/net/swedz/little_big_redstone/block/microchip/MicrochipBlock.java
@@ -18,12 +18,11 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.swedz.little_big_redstone.LBRItems;
-import net.swedz.little_big_redstone.item.DyeColoredItem;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessContext;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.tesseract.neoforge.api.TickableBlock;
 
-public final class MicrochipBlock extends Block implements TickableBlock, DyeColoredItem
+public final class MicrochipBlock extends Block implements TickableBlock
 {
 	public static final BooleanProperty UP    = BooleanProperty.create("up");
 	public static final BooleanProperty DOWN  = BooleanProperty.create("down");
@@ -49,7 +48,8 @@ public final class MicrochipBlock extends Block implements TickableBlock, DyeCol
 	
 	public MicrochipBlock(Properties properties, DyeColor color)
 	{
-		super(properties.isRedstoneConductor(Blocks::never));
+		super(properties
+				.isRedstoneConductor(Blocks::never));
 		
 		this.color = color;
 		
@@ -74,7 +74,6 @@ public final class MicrochipBlock extends Block implements TickableBlock, DyeCol
 		}
 	}
 	
-	@Override
 	public DyeColor color()
 	{
 		return color;

--- a/src/main/java/net/swedz/little_big_redstone/client/item/StickyNoteItemRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/client/item/StickyNoteItemRenderer.java
@@ -31,7 +31,7 @@ public final class StickyNoteItemRenderer extends BlockEntityWithoutLevelRendere
 	@Override
 	public void renderByItem(ItemStack stack, ItemDisplayContext displayContext, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay)
 	{
-		if(!(stack.getItem() instanceof StickyNoteItem stickyNoteItem))
+		if(!StickyNoteItem.hasRelevantComponents(stack))
 		{
 			return;
 		}

--- a/src/main/java/net/swedz/little_big_redstone/client/model/stickynote/StickyNoteModelData.java
+++ b/src/main/java/net/swedz/little_big_redstone/client/model/stickynote/StickyNoteModelData.java
@@ -24,10 +24,10 @@ public final class StickyNoteModelData
 	
 	public static StickyNoteModelData of(ItemStack stack)
 	{
-		if(stack.getItem() instanceof StickyNoteItem stickyNoteItem)
+		if(StickyNoteItem.hasRelevantComponents(stack))
 		{
 			var note = stack.get(LBRComponents.STICKY_NOTE);
-			var color = stickyNoteItem.color();
+			var color = stack.get(LBRComponents.STICKY_NOTE_COLOR);
 			var textColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 			return new StickyNoteModelData(color, textColor, !note.isEmpty());
 		}

--- a/src/main/java/net/swedz/little_big_redstone/entity/stickynote/StickyNoteView.java
+++ b/src/main/java/net/swedz/little_big_redstone/entity/stickynote/StickyNoteView.java
@@ -7,7 +7,6 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.swedz.little_big_redstone.LBRComponents;
-import net.swedz.little_big_redstone.item.stickynote.StickyNoteItem;
 
 public record StickyNoteView(
 		DyeColor color,
@@ -25,7 +24,7 @@ public record StickyNoteView(
 	public StickyNoteView(ItemStack stack)
 	{
 		this(
-				((StickyNoteItem) stack.getItem()).color(),
+				stack.get(LBRComponents.STICKY_NOTE_COLOR),
 				stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR),
 				stack.get(LBRComponents.STICKY_NOTE).parsed()
 		);

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/MicrochipScreen.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/MicrochipScreen.java
@@ -171,7 +171,7 @@ public final class MicrochipScreen extends AbstractContainerScreen<MicrochipMenu
 			graphics.pose().scale(microchipWidget.viewPosition().zoom(), microchipWidget.viewPosition().zoom(), 1);
 			graphics.pose().translate(-microchipWidget.viewPosition().x(), -microchipWidget.viewPosition().y(), 0);
 			
-			if(carried.getItem() instanceof StickyNoteItem)
+			if(StickyNoteItem.hasRelevantComponents(carried))
 			{
 				int itemX = Screen.hasControlDown() ? getGridSnappedCoord(boardMouseX) : (boardMouseX - 8);
 				int itemY = Screen.hasControlDown() ? getGridSnappedCoord(boardMouseY) : (boardMouseY - 8);

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/panel/MicrochipRenderBoardPanel.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/panel/MicrochipRenderBoardPanel.java
@@ -162,7 +162,7 @@ public final class MicrochipRenderBoardPanel extends MicrochipRenderPanel
 			int boardMouseX = context.boardMouseX();
 			int boardMouseY = context.boardMouseY();
 			
-			boolean isStickyNote = carried.getItem() instanceof StickyNoteItem;
+			boolean isStickyNote = StickyNoteItem.hasRelevantComponents(carried);
 			boolean isLogic = carried.has(LBRComponents.LOGIC_CONFIG);
 			if(isStickyNote || isLogic)
 			{

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/widget/MicrochipWidget.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/widget/MicrochipWidget.java
@@ -325,7 +325,7 @@ public final class MicrochipWidget implements GuiEventListener, Renderable, Narr
 		boolean leftClick = button == InputConstants.MOUSE_BUTTON_LEFT;
 		boolean rightClick = button == InputConstants.MOUSE_BUTTON_RIGHT;
 		if((leftClick || rightClick) &&
-		   carried.getItem() instanceof StickyNoteItem &&
+		   StickyNoteItem.hasRelevantComponents(carried) &&
 		   context.shouldInteractBoard())
 		{
 			int placeX = Screen.hasControlDown() ? MicrochipScreen.getGridSnappedCoord(x) : (x - 8);

--- a/src/main/java/net/swedz/little_big_redstone/gui/noteboard/NoteBoardScreen.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/noteboard/NoteBoardScreen.java
@@ -141,7 +141,7 @@ public final class NoteBoardScreen extends AbstractContainerScreen<NoteBoardMenu
 		{
 			var carried = menu.getCarried();
 			if(holdingHudNote ||
-			   carried.getItem() instanceof StickyNoteItem)
+			   StickyNoteItem.hasRelevantComponents(carried))
 			{
 				int placeXRaw = x - (carriedNoteSize / 2);
 				int placeYRaw = y - (carriedNoteSize / 2);
@@ -242,7 +242,7 @@ public final class NoteBoardScreen extends AbstractContainerScreen<NoteBoardMenu
 	public boolean mouseReleased(double mouseX, double mouseY, int button)
 	{
 		if(this.isOutsideInventory(mouseX, mouseY) &&
-		   menu.getCarried().getItem() instanceof StickyNoteItem)
+		   StickyNoteItem.hasRelevantComponents(menu.getCarried()))
 		{
 			return false;
 		}
@@ -284,7 +284,7 @@ public final class NoteBoardScreen extends AbstractContainerScreen<NoteBoardMenu
 	private boolean shouldRenderFloatingNote(int mouseX, int mouseY, ItemStack stack)
 	{
 		return this.isOutsideInventory(mouseX, mouseY) &&
-			   stack.getItem() instanceof StickyNoteItem;
+			   StickyNoteItem.hasRelevantComponents(stack);
 	}
 	
 	private void renderFloatingNote(TesseractGuiGraphics graphics, int mouseX, int mouseY, ItemStack stack)
@@ -359,7 +359,7 @@ public final class NoteBoardScreen extends AbstractContainerScreen<NoteBoardMenu
 		{
 			var carried = menu.getCarried();
 			if(holdingHudNote ||
-			   carried.getItem() instanceof StickyNoteItem)
+			   StickyNoteItem.hasRelevantComponents(carried))
 			{
 				carriedNoteSize = this.resize(carriedNoteSize, scrollY);
 				return true;

--- a/src/main/java/net/swedz/little_big_redstone/gui/noteboard/contents/NoteBoardStickyNote.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/noteboard/contents/NoteBoardStickyNote.java
@@ -56,7 +56,7 @@ public record NoteBoardStickyNote(
 	public NoteBoardStickyNote
 	{
 		Assert.notNull(stack);
-		Assert.that(stack.getItem() instanceof StickyNoteItem);
+		Assert.that(StickyNoteItem.hasRelevantComponents(stack));
 		Assert.that(size > 0);
 	}
 	

--- a/src/main/java/net/swedz/little_big_redstone/gui/stickynote/reference/HeldItemStickyNoteReference.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/stickynote/reference/HeldItemStickyNoteReference.java
@@ -23,12 +23,12 @@ public final class HeldItemStickyNoteReference implements StickyNoteReference
 	
 	public HeldItemStickyNoteReference(InteractionHand hand, ItemStack stack)
 	{
-		if(!(stack.getItem() instanceof StickyNoteItem item))
+		if(!StickyNoteItem.hasRelevantComponents(stack))
 		{
 			throw new IllegalArgumentException("Non-sticky note item supplied");
 		}
 		this.hand = hand;
-		this.color = item.color();
+		this.color = stack.get(LBRComponents.STICKY_NOTE_COLOR);
 		this.textColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 		this.text = stack.getOrDefault(LBRComponents.STICKY_NOTE, StickyNote.EMPTY).text();
 		this.editable = stack.get(LBRComponents.STICKY_NOTE_EDITABLE);
@@ -83,7 +83,7 @@ public final class HeldItemStickyNoteReference implements StickyNoteReference
 	public void saveServer(Level level, Player player)
 	{
 		var stack = player.getItemInHand(hand);
-		if(stack.getItem() instanceof StickyNoteItem item &&
+		if(StickyNoteItem.hasRelevantComponents(stack) &&
 		   stack.get(LBRComponents.STICKY_NOTE_EDITABLE))
 		{
 			stack.set(LBRComponents.STICKY_NOTE, new StickyNote(text));

--- a/src/main/java/net/swedz/little_big_redstone/item/DyeColoredItem.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/DyeColoredItem.java
@@ -1,8 +1,0 @@
-package net.swedz.little_big_redstone.item;
-
-import net.minecraft.world.item.DyeColor;
-
-public interface DyeColoredItem
-{
-	DyeColor color();
-}

--- a/src/main/java/net/swedz/little_big_redstone/item/floppydisk/FloppyDiskItem.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/floppydisk/FloppyDiskItem.java
@@ -25,7 +25,6 @@ import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRComponents;
 import net.swedz.little_big_redstone.LBRTags;
 import net.swedz.little_big_redstone.block.microchip.MicrochipBlockEntity;
-import net.swedz.little_big_redstone.item.DyeColoredItem;
 import net.swedz.little_big_redstone.item.tooltip.ItemContainerContentsTooltipData;
 import net.swedz.little_big_redstone.microchip.Microchip;
 import net.swedz.little_big_redstone.network.packet.FloppyDiskGuiOverlayUpdatePacket;
@@ -37,22 +36,14 @@ import java.util.List;
 import java.util.Optional;
 
 @EventBusSubscriber(modid = LBR.ID)
-public final class FloppyDiskItem extends Item implements DyeColoredItem
+public final class FloppyDiskItem extends Item
 {
-	private final DyeColor color;
-	
 	public FloppyDiskItem(Properties properties, DyeColor color)
 	{
 		super(properties
 				.stacksTo(1)
+				.component(LBRComponents.FLOPPY_DISK_COLOR, color)
 				.component(LBRComponents.FLOPPY_DISK, null));
-		this.color = color;
-	}
-	
-	@Override
-	public DyeColor color()
-	{
-		return color;
 	}
 	
 	public static ItemStack getHeldStack(Player player)

--- a/src/main/java/net/swedz/little_big_redstone/item/logicarray/LogicArrayItem.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/logicarray/LogicArrayItem.java
@@ -21,30 +21,23 @@ import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.swedz.little_big_redstone.LBRComponents;
 import net.swedz.little_big_redstone.gui.logicarray.LogicArrayMenu;
-import net.swedz.little_big_redstone.item.DyeColoredItem;
 import net.swedz.little_big_redstone.item.tooltip.ItemContainerContentsTooltipData;
 import net.swedz.tesseract.neoforge.helper.TransferHelper;
 
 import java.util.Optional;
 
-public final class LogicArrayItem extends Item implements DyeColoredItem
+public final class LogicArrayItem extends Item
 {
 	public static final int ROWS      = 4;
 	public static final int COLUMNS   = 7;
 	public static final int MAX_SLOTS = ROWS * COLUMNS;
 	
-	private final DyeColor color;
-	
 	public LogicArrayItem(Properties properties, DyeColor color)
 	{
-		super(properties.stacksTo(1).component(LBRComponents.LOGIC_ARRAY_STORAGE, ItemContainerContents.EMPTY));
-		this.color = color;
-	}
-	
-	@Override
-	public DyeColor color()
-	{
-		return color;
+		super(properties
+				.stacksTo(1)
+				.component(LBRComponents.LOGIC_ARRAY_COLOR, color)
+				.component(LBRComponents.LOGIC_ARRAY_STORAGE, ItemContainerContents.EMPTY));
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/item/stickynote/StickyNoteItem.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/stickynote/StickyNoteItem.java
@@ -24,7 +24,6 @@ import net.swedz.little_big_redstone.LBRComponents;
 import net.swedz.little_big_redstone.entity.stickynote.StickyNoteEntity;
 import net.swedz.little_big_redstone.entity.stickynote.StickyNoteView;
 import net.swedz.little_big_redstone.gui.stickynote.reference.HeldItemStickyNoteReference;
-import net.swedz.little_big_redstone.item.DyeColoredItem;
 import net.swedz.little_big_redstone.item.stickynote.tooltip.StickyNoteTooltipData;
 import net.swedz.little_big_redstone.proxy.LBRProxy;
 import net.swedz.tesseract.neoforge.helper.DirectionHelper;
@@ -34,7 +33,7 @@ import net.swedz.tesseract.neoforge.proxy.Proxies;
 import java.util.List;
 import java.util.Optional;
 
-public final class StickyNoteItem extends Item implements DyeColoredItem
+public final class StickyNoteItem extends Item
 {
 	public static DyeColor getDefaultTextColor(DyeColor color)
 	{
@@ -45,22 +44,21 @@ public final class StickyNoteItem extends Item implements DyeColoredItem
 		};
 	}
 	
-	private final DyeColor color;
+	public static boolean hasRelevantComponents(ItemStack stack)
+	{
+		return stack.has(LBRComponents.STICKY_NOTE) &&
+			   stack.has(LBRComponents.STICKY_NOTE_COLOR) &&
+			   stack.has(LBRComponents.STICKY_NOTE_TEXT_COLOR);
+	}
 	
 	public StickyNoteItem(Properties properties, DyeColor color)
 	{
 		super(properties
 				.component(LBRComponents.STICKY_NOTE, StickyNote.EMPTY)
+				.component(LBRComponents.STICKY_NOTE_COLOR, color)
 				.component(LBRComponents.STICKY_NOTE_TEXT_COLOR, getDefaultTextColor(color))
 				.component(LBRComponents.STICKY_NOTE_EDITABLE, true)
 				.component(LBRComponents.STICKY_NOTE_DISPLAY_ITEM, ItemInstance.EMPTY));
-		this.color = color;
-	}
-	
-	@Override
-	public DyeColor color()
-	{
-		return color;
 	}
 	
 	private boolean mayPlace(Player player, Direction direction, ItemStack itemStack, BlockPos pos)
@@ -125,6 +123,7 @@ public final class StickyNoteItem extends Item implements DyeColoredItem
 		
 		var facing = direction.getAxis().isVertical() ? Direction.fromYRot(player.getYRot()).getOpposite() : Direction.SOUTH;
 		var quadrant = findClosestQuadrant(context.getClickedPos(), direction, facing, context.getClickLocation());
+		var color = stack.get(LBRComponents.STICKY_NOTE_COLOR);
 		var textColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 		var editable = stack.get(LBRComponents.STICKY_NOTE_EDITABLE);
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/note/MicrochipStickyNotes.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/note/MicrochipStickyNotes.java
@@ -57,9 +57,9 @@ public final class MicrochipStickyNotes extends MicrochipObjectContainer<StickyN
 	
 	public StickyNoteEntry add(int x, int y, ItemStack stack)
 	{
-		if(stack.getItem() instanceof StickyNoteItem stickyNote)
+		if(StickyNoteItem.hasRelevantComponents(stack))
 		{
-			var color = stickyNote.color();
+			var color = stack.get(LBRComponents.STICKY_NOTE_COLOR);
 			var note = stack.get(LBRComponents.STICKY_NOTE);
 			var textColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 			var editable = stack.get(LBRComponents.STICKY_NOTE_EDITABLE);

--- a/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeMicrochipObjectPacket.java
+++ b/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeMicrochipObjectPacket.java
@@ -51,7 +51,7 @@ public record PlaceTakeMicrochipObjectPacket(
 			ItemStack heldItem = menu.getCarried();
 			if(place)
 			{
-				if(heldItem.getItem() instanceof StickyNoteItem)
+				if(StickyNoteItem.hasRelevantComponents(heldItem))
 				{
 					if(microchip.size().bounds().normalize().contains(new Bounds(x, y, 16, 16)))
 					{

--- a/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeNoteBoardStickyNotePacket.java
+++ b/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeNoteBoardStickyNotePacket.java
@@ -58,7 +58,7 @@ public record PlaceTakeNoteBoardStickyNotePacket(
 			
 			if(place)
 			{
-				if(carried.getItem() instanceof StickyNoteItem)
+				if(StickyNoteItem.hasRelevantComponents(carried))
 				{
 					if(x >= 0 && x <= 1 && y >= 0 && y <= 1)
 					{

--- a/src/main/java/net/swedz/little_big_redstone/network/packet/StickyNotePacket.java
+++ b/src/main/java/net/swedz/little_big_redstone/network/packet/StickyNotePacket.java
@@ -72,7 +72,7 @@ public record StickyNotePacket(
 		{
 			var hand = data == 0 ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
 			var stack = player.getItemInHand(hand);
-			return stack.getItem() instanceof StickyNoteItem ? new HeldItemStickyNoteReference(hand, stack) : null;
+			return StickyNoteItem.hasRelevantComponents(stack) ? new HeldItemStickyNoteReference(hand, stack) : null;
 		}),
 		
 		MICROCHIP((player, data) ->

--- a/src/main/java/net/swedz/little_big_redstone/recipe/CopyStickyNoteRecipe.java
+++ b/src/main/java/net/swedz/little_big_redstone/recipe/CopyStickyNoteRecipe.java
@@ -28,13 +28,14 @@ public final class CopyStickyNoteRecipe extends CustomRecipe
 		boolean hasTargetNote = false;
 		for(var stack : input.items())
 		{
-			if(stack.getItem() instanceof StickyNoteItem item)
+			if(StickyNoteItem.hasRelevantComponents(stack))
 			{
-				if(color != null && !color.equals(item.color()))
+				var stackColor = stack.get(LBRComponents.STICKY_NOTE_COLOR);
+				if(color != null && !color.equals(stackColor))
 				{
 					return false;
 				}
-				color = item.color();
+				color = stackColor;
 				
 				var stackTextColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 				if(textColor != null && !textColor.equals(stackTextColor))
@@ -78,13 +79,14 @@ public final class CopyStickyNoteRecipe extends CustomRecipe
 		var target = ItemStack.EMPTY;
 		for(var stack : input.items())
 		{
-			if(stack.getItem() instanceof StickyNoteItem item)
+			if(StickyNoteItem.hasRelevantComponents(stack))
 			{
-				if(color != null && !color.equals(item.color()))
+				var stackColor = stack.get(LBRComponents.STICKY_NOTE_COLOR);
+				if(color != null && !color.equals(stackColor))
 				{
 					return ItemStack.EMPTY;
 				}
-				color = item.color();
+				color = stackColor;
 				
 				var stackTextColor = stack.get(LBRComponents.STICKY_NOTE_TEXT_COLOR);
 				if(textColor != null && !textColor.equals(stackTextColor))

--- a/src/main/java/net/swedz/little_big_redstone/recipe/DataRetainingDyeRecipe.java
+++ b/src/main/java/net/swedz/little_big_redstone/recipe/DataRetainingDyeRecipe.java
@@ -1,8 +1,8 @@
 package net.swedz.little_big_redstone.recipe;
 
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.Item;
@@ -18,11 +18,11 @@ import net.swedz.little_big_redstone.LBRComponents;
 import net.swedz.little_big_redstone.LBRItems;
 import net.swedz.little_big_redstone.LBRRecipeTypes;
 import net.swedz.little_big_redstone.LBRTags;
-import net.swedz.little_big_redstone.item.DyeColoredItem;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public final class DataRetainingDyeRecipe extends CustomRecipe
 {
@@ -33,12 +33,14 @@ public final class DataRetainingDyeRecipe extends CustomRecipe
 	
 	private static final Map<TagKey<Item>, ColorableItemTagHandler> TAG_RESULTS = Map.of(
 			LBRTags.Items.MICROCHIPS,
-			new ColorableItemTagHandler((color) -> LBRBlocks.microchip(color).get()),
+			new ColorableItemTagHandler(
+					LBRComponents.MICROCHIP_COLOR,
+					(color) -> LBRBlocks.microchip(color).get()
+			),
 			
 			LBRTags.Items.LOGIC_COMPONENTS,
 			new ColorableItemTagHandler(
-					(stack) ->
-							Optional.ofNullable(stack.get(LBRComponents.LOGIC_COLOR)),
+					LBRComponents.LOGIC_COLOR,
 					(original, color) ->
 					{
 						var output = original.copyWithCount(1);
@@ -48,48 +50,54 @@ public final class DataRetainingDyeRecipe extends CustomRecipe
 			),
 			
 			LBRTags.Items.LOGIC_ARRAYS,
-			new ColorableItemTagHandler(LBRItems::logicArray),
+			new ColorableItemTagHandler(
+					LBRComponents.LOGIC_ARRAY_COLOR,
+					LBRItems::logicArray
+			),
 			
 			LBRTags.Items.FLOPPY_DISKS,
-			new ColorableItemTagHandler(LBRItems::floppyDisk),
+			new ColorableItemTagHandler(
+					LBRComponents.FLOPPY_DISK_COLOR,
+					LBRItems::floppyDisk
+			),
 			
 			LBRTags.Items.STICKY_NOTES,
-			new ColorableItemTagHandler(LBRItems::stickyNote)
+			new ColorableItemTagHandler(
+					LBRComponents.STICKY_NOTE_COLOR,
+					LBRItems::stickyNote
+			)
 	);
 	
-	private record ColorableItemTagHandler(ItemColorGetter colorGetter, ColoredItemFactory coloredItemFactory)
+	private record ColorableItemTagHandler(
+			ItemColorGetter colorGetter,
+			ColoredItemFactory coloredItemFactory
+	)
 	{
-		public ColorableItemTagHandler(ColoredItemFactory coloredItemFactory)
+		public ColorableItemTagHandler(
+				Supplier<DataComponentType<DyeColor>> dyeColorComponent,
+				ColoredItemFactory coloredItemFactory
+		)
 		{
-			this(ItemColorGetter.DEFAULT, coloredItemFactory);
+			this(ItemColorGetter.forComponent(dyeColorComponent), coloredItemFactory);
 		}
 		
-		public ColorableItemTagHandler(ColoredItemFactory.Simple coloredItemFactory)
+		public ColorableItemTagHandler(
+				Supplier<DataComponentType<DyeColor>> dyeColorComponent,
+				ColoredItemFactory.Simple coloredItemFactory
+		)
 		{
-			this(ItemColorGetter.DEFAULT, coloredItemFactory);
+			this(ItemColorGetter.forComponent(dyeColorComponent), coloredItemFactory);
 		}
 	}
 	
 	private interface ItemColorGetter
 	{
-		ItemColorGetter DEFAULT = (stack) ->
+		static ItemColorGetter forComponent(Supplier<DataComponentType<DyeColor>> component)
 		{
-			DyeColoredItem dyeColoredItem;
-			if(stack.getItem() instanceof DyeColoredItem item)
-			{
-				dyeColoredItem = item;
-			}
-			else if(stack.getItem() instanceof BlockItem blockItem &&
-					blockItem.getBlock().asItem() instanceof DyeColoredItem item)
-			{
-				dyeColoredItem = item;
-			}
-			else
-			{
-				return Optional.empty();
-			}
-			return Optional.of(dyeColoredItem.color());
-		};
+			return (stack) -> stack.has(component) ?
+					Optional.of(stack.get(component)) :
+					Optional.empty();
+		}
 		
 		Optional<DyeColor> get(ItemStack stack);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/recipe/SealStickyNoteRecipe.java
+++ b/src/main/java/net/swedz/little_big_redstone/recipe/SealStickyNoteRecipe.java
@@ -26,7 +26,7 @@ public final class SealStickyNoteRecipe extends CustomRecipe
 		boolean hasSealant = false;
 		for(var stack : input.items())
 		{
-			if(stack.getItem() instanceof StickyNoteItem item)
+			if(StickyNoteItem.hasRelevantComponents(stack))
 			{
 				if(hasNote ||
 				   !stack.get(LBRComponents.STICKY_NOTE_EDITABLE))
@@ -58,7 +58,7 @@ public final class SealStickyNoteRecipe extends CustomRecipe
 		boolean hasSealant = false;
 		for(var stack : input.items())
 		{
-			if(stack.getItem() instanceof StickyNoteItem item)
+			if(StickyNoteItem.hasRelevantComponents(stack))
 			{
 				if(!note.isEmpty() ||
 				   !stack.get(LBRComponents.STICKY_NOTE_EDITABLE))


### PR DESCRIPTION
Makes things a bit more data driven. Not that anyone would realistically use this, but it's there. This is just to be more in line with the way Minecraft is going with data driven items.

Components for color of logic arrays, floppy disks, and microchips will be removed in 26.1, since they are only used for recipes here. Recipes in 26.1 are much better.