### PR TITLE
Use a registry for LogicTypes

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/LBR.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBR.java
@@ -11,6 +11,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.registries.NewRegistryEvent;
 import net.swedz.little_big_redstone.datagen.client.provider.LanguageDatagenProvider;
 import net.swedz.little_big_redstone.guide.LBRGuide;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
@@ -46,7 +47,10 @@ public final class LBR
 	{
 		setupText();
 		
-		LogicTypes.init();
+		bus.addListener(NewRegistryEvent.class, (event) ->
+				event.register(LogicTypes.REGISTRY));
+		
+		LBRLogicTypes.init(bus);
 		AwarenessTypes.init();
 		
 		LBRComponents.init(bus);

--- a/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.tesseract.neoforge.registry.holder.ItemHolder;
 
 import java.util.Collections;
@@ -20,28 +21,30 @@ public final class LBRCreativeTabs
 {
 	private static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, LBR.ID);
 	
-	public static final Supplier<CreativeModeTab> CREATIVE_TAB = CREATIVE_MODE_TABS.register(LBR.ID, () -> CreativeModeTab.builder()
-			.title(Component.translatable(LBR.id(LBR.ID).toLanguageKey("itemGroup")))
-			.icon(() -> LBRBlocks.microchip(DyeColor.RED).get().asItem().getDefaultInstance())
-			.displayItems((params, output) ->
-			{
-				Comparator<ItemHolder> compareBySortOrder = Comparator.comparing(ItemHolder::sortOrder);
-				Comparator<ItemHolder> compareByName = Comparator.comparing((i) -> i.identifier().id());
-				LBRItems.values().stream()
-						.sorted(compareBySortOrder.thenComparing(compareByName))
-						.forEach(output::accept);
-			})
-			.build());
+	public static final Supplier<CreativeModeTab> CREATIVE_TAB = CREATIVE_MODE_TABS.register(
+			LBR.ID,
+			() -> CreativeModeTab.builder()
+					.title(Component.translatable(LBR.id(LBR.ID).toLanguageKey("itemGroup")))
+					.icon(() -> LBRBlocks.microchip(DyeColor.RED).get().asItem().getDefaultInstance())
+					.displayItems((params, output) ->
+					{
+						Comparator<ItemHolder> compareBySortOrder = Comparator.comparing(ItemHolder::sortOrder);
+						Comparator<ItemHolder> compareByName = Comparator.comparing((i) -> i.identifier().id());
+						LBRItems.values().stream()
+								.sorted(compareBySortOrder.thenComparing(compareByName))
+								.forEach(output::accept);
+					})
+					.build()
+	);
 	
 	private static final Supplier<List<ItemStack>> LOGIC_ARRAY_ITEMS = Suppliers.memoize(() ->
 	{
 		List<ItemStack> items = Lists.newArrayList();
 		items.add(LBRItems.REDSTONE_BIT.asItem().getDefaultInstance());
-		for(var type : LBRLogicTypes.values())
-		{
-			var stack = type.toStack(type.defaultFactory().create());
-			items.add(stack);
-		}
+		items.addAll(LogicTypes.REGISTRY.stream()
+				.sorted(Comparator.comparing((type) -> type.id().getNamespace()))
+				.map((type) -> type.toStack(type.defaultFactory().create()))
+				.toList());
 		return Collections.unmodifiableList(items);
 	});
 	

--- a/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
@@ -9,7 +9,6 @@ import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredRegister;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.tesseract.neoforge.registry.holder.ItemHolder;
 
 import java.util.Collections;
@@ -38,7 +37,7 @@ public final class LBRCreativeTabs
 	{
 		List<ItemStack> items = Lists.newArrayList();
 		items.add(LBRItems.REDSTONE_BIT.asItem().getDefaultInstance());
-		for(LogicType type : LBRLogicTypes.values())
+		for(var type : LBRLogicTypes.values())
 		{
 			var stack = type.toStack(type.defaultFactory().create());
 			items.add(stack);

--- a/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRCreativeTabs.java
@@ -10,7 +10,6 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.tesseract.neoforge.registry.holder.ItemHolder;
 
 import java.util.Collections;
@@ -39,7 +38,7 @@ public final class LBRCreativeTabs
 	{
 		List<ItemStack> items = Lists.newArrayList();
 		items.add(LBRItems.REDSTONE_BIT.asItem().getDefaultInstance());
-		for(LogicType type : LogicTypes.values())
+		for(LogicType type : LBRLogicTypes.values())
 		{
 			var stack = type.toStack(type.defaultFactory().create());
 			items.add(stack);

--- a/src/main/java/net/swedz/little_big_redstone/LBRItems.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRItems.java
@@ -7,13 +7,12 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.registries.DeferredRegister;
-import net.swedz.little_big_redstone.item.floppydisk.FloppyDiskItem;
 import net.swedz.little_big_redstone.item.LogicItem;
+import net.swedz.little_big_redstone.item.floppydisk.FloppyDiskItem;
 import net.swedz.little_big_redstone.item.logicarray.LogicArrayItem;
 import net.swedz.little_big_redstone.item.logicarray.LogicArrayItemHandler;
 import net.swedz.little_big_redstone.item.stickynote.StickyNoteItem;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.tesseract.api.Assert;
 import net.swedz.tesseract.neoforge.helper.model.BasicCustomLoaderBuilder;
 import net.swedz.tesseract.neoforge.registry.SortOrder;
@@ -76,9 +75,9 @@ public final class LBRItems
 	{
 		{
 			int index = 0;
-			for(var type : LogicTypes.values())
+			for(var type : LBRLogicTypes.values())
 			{
-				createLogic(type.id(), type.englishName(), type, index++).register();
+				createLogic(type.id().getPath(), type.englishName(), type, index++).register();
 			}
 		}
 		

--- a/src/main/java/net/swedz/little_big_redstone/LBRItems.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRItems.java
@@ -134,7 +134,7 @@ public final class LBRItems
 		return holder;
 	}
 	
-	private static ItemHolder<LogicItem> createLogic(String id, String englishName, LogicType<?, ?> type, int order)
+	private static ItemHolder<LogicItem> createLogic(String id, String englishName, LogicType type, int order)
 	{
 		return create(id, englishName, (p) -> new LogicItem(p, type), LBRSortOrder.LOGIC.and(order))
 				.tag(LBRTags.Items.LOGIC_COMPONENTS);

--- a/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
@@ -1,0 +1,137 @@
+package net.swedz.little_big_redstone;
+
+import com.google.common.collect.Sets;
+import com.mojang.serialization.MapCodec;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicFactory;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
+import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculator;
+import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparator;
+import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparatorConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.debug.LogicDebugger;
+import net.swedz.little_big_redstone.microchip.object.logic.debug.LogicDebuggerConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.ANDGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.LogicGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.NANDGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.NORGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.NOTGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.ORGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.XORGate;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ANDGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NANDGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NORGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NOTGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ORGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.gate.config.XORGateConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.io.LogicIO;
+import net.swedz.little_big_redstone.microchip.object.logic.io.LogicIOConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.latch.rs.RSNORLatch;
+import net.swedz.little_big_redstone.microchip.object.logic.latch.rs.RSNORLatchConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.latch.tflipflop.TFlipFlop;
+import net.swedz.little_big_redstone.microchip.object.logic.latch.tflipflop.TFlipFlopConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.pulse.PulseThrottler;
+import net.swedz.little_big_redstone.microchip.object.logic.pulse.PulseThrottlerConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRandomizer;
+import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRandomizerConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReader;
+import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReaderConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelector;
+import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelectorConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.sequencer.LogicSequencer;
+import net.swedz.little_big_redstone.microchip.object.logic.sequencer.LogicSequencerConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.tag.LogicTag;
+import net.swedz.little_big_redstone.microchip.object.logic.tag.LogicTagConfig;
+import org.apache.commons.lang3.mutable.MutableInt;
+
+import java.util.Collections;
+import java.util.Set;
+
+public final class LBRLogicTypes
+{
+	private static final DeferredRegister<LogicType<?, ?>> REGISTRY = DeferredRegister.create(LogicTypes.REGISTRY, LBR.ID);
+	
+	private static final Set<LogicType<?, ?>> VALUES = Sets.newHashSet();
+	
+	private static final MutableInt SYMBOL = new MutableInt();
+	
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicDebugger, LogicDebuggerConfig>> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
+	
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicIO, LogicIOConfig>>         IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicReader, LogicReaderConfig>> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicTag, LogicTagConfig>>       TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
+	
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<NOTGate, NOTGateConfig>>   NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<ANDGate, ANDGateConfig>>   AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<NANDGate, NANDGateConfig>> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<ORGate, ORGateConfig>>     OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<NORGate, NORGateConfig>>   NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<XORGate, XORGateConfig>>   XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
+	
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicSequencer, LogicSequencerConfig>>   SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<PulseThrottler, PulseThrottlerConfig>>   PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicSelector, LogicSelectorConfig>>     SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicRandomizer, LogicRandomizerConfig>> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicComparator, LogicComparatorConfig>> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicCalculator, LogicCalculatorConfig>> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<TFlipFlop, TFlipFlopConfig>>             T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
+	public static final DeferredHolder<LogicType<?, ?>, LogicType<RSNORLatch, RSNORLatchConfig>>           RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
+	
+	public static Set<LogicType<?, ?>> values()
+	{
+		return Collections.unmodifiableSet(VALUES);
+	}
+	
+	private static <T extends LogicComponent<T, C>, C extends LogicConfig<C>> DeferredHolder<LogicType<?, ?>, LogicType<T, C>> register(
+			String name,
+			String englishName,
+			MapCodec<T> codec,
+			StreamCodec<ByteBuf, T> streamCodec,
+			LogicFactory<T> defaultFactory,
+			MapCodec<C> configCodec,
+			StreamCodec<ByteBuf, C> configStreamCodec,
+			C defaultConfig
+	)
+	{
+		var id = LBR.id(name);
+		var type = new LogicType<>(
+				id,
+				englishName,
+				(char) (SYMBOL.getAndIncrement() + (int) '0'),
+				codec,
+				streamCodec,
+				defaultFactory,
+				configCodec,
+				configStreamCodec,
+				defaultConfig
+		);
+		VALUES.add(type);
+		return REGISTRY.register(name, () -> type);
+	}
+	
+	private static <T extends LogicGate<T, C>, C extends LogicConfig<C>> DeferredHolder<LogicType<?, ?>, LogicType<T, C>> registerGate(
+			String id,
+			String englishName,
+			MapCodec<T> codec,
+			StreamCodec<ByteBuf, T> streamCodec,
+			LogicFactory<T> defaultFactory,
+			MapCodec<C> configCodec,
+			StreamCodec<ByteBuf, C> configStreamCodec,
+			C defaultConfig
+	)
+	{
+		return register(id + "_gate", englishName + " Gate", codec, streamCodec, defaultFactory, configCodec, configStreamCodec, defaultConfig);
+	}
+	
+	public static void init(IEventBus bus)
+	{
+		REGISTRY.register(bus);
+	}
+}

--- a/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
@@ -56,40 +56,40 @@ import java.util.Set;
 
 public final class LBRLogicTypes
 {
-	private static final DeferredRegister<LogicType<?, ?>> REGISTRY = DeferredRegister.create(LogicTypes.REGISTRY, LBR.ID);
+	private static final DeferredRegister<LogicType> REGISTRY = DeferredRegister.create(LogicTypes.REGISTRY, LBR.ID);
 	
-	private static final Set<LogicType<?, ?>> VALUES = Sets.newHashSet();
+	private static final Set<LogicType> VALUES = Sets.newHashSet();
 	
 	private static final MutableInt SYMBOL = new MutableInt();
 	
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicDebugger, LogicDebuggerConfig>> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicIO, LogicIOConfig>>         IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicReader, LogicReaderConfig>> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicTag, LogicTagConfig>>       TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<NOTGate, NOTGateConfig>>   NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<ANDGate, ANDGateConfig>>   AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<NANDGate, NANDGateConfig>> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<ORGate, ORGateConfig>>     OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<NORGate, NORGateConfig>>   NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<XORGate, XORGateConfig>>   XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicSequencer, LogicSequencerConfig>>   SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<PulseThrottler, PulseThrottlerConfig>>   PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicSelector, LogicSelectorConfig>>     SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicRandomizer, LogicRandomizerConfig>> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicComparator, LogicComparatorConfig>> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<LogicCalculator, LogicCalculatorConfig>> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<TFlipFlop, TFlipFlopConfig>>             T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
-	public static final DeferredHolder<LogicType<?, ?>, LogicType<RSNORLatch, RSNORLatchConfig>>           RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
+	public static final DeferredHolder<LogicType, LogicType> RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
 	
-	public static Set<LogicType<?, ?>> values()
+	public static Set<LogicType> values()
 	{
 		return Collections.unmodifiableSet(VALUES);
 	}
 	
-	private static <T extends LogicComponent<T, C>, C extends LogicConfig<C>> DeferredHolder<LogicType<?, ?>, LogicType<T, C>> register(
+	private static <T extends LogicComponent<T, C>, C extends LogicConfig> DeferredHolder<LogicType, LogicType> register(
 			String name,
 			String englishName,
 			MapCodec<T> codec,
@@ -101,7 +101,7 @@ public final class LBRLogicTypes
 	)
 	{
 		var id = LBR.id(name);
-		var type = new LogicType<>(
+		var type = new LogicType(
 				id,
 				englishName,
 				(char) (SYMBOL.getAndIncrement() + (int) '0'),
@@ -116,7 +116,7 @@ public final class LBRLogicTypes
 		return REGISTRY.register(name, () -> type);
 	}
 	
-	private static <T extends LogicGate<T, C>, C extends LogicConfig<C>> DeferredHolder<LogicType<?, ?>, LogicType<T, C>> registerGate(
+	private static <T extends LogicGate<T, C>, C extends LogicConfig> DeferredHolder<LogicType, LogicType> registerGate(
 			String id,
 			String englishName,
 			MapCodec<T> codec,

--- a/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
@@ -1,15 +1,13 @@
 package net.swedz.little_big_redstone;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.neoforged.bus.api.IEventBus;
-import net.swedz.little_big_redstone.microchip.object.logic.register.DeferredLogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicFactory;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.register.LogicTypeDeferredRegister;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculator;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparator;
@@ -42,6 +40,8 @@ import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRand
 import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRandomizerConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReader;
 import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReaderConfig;
+import net.swedz.little_big_redstone.microchip.object.logic.register.DeferredLogicType;
+import net.swedz.little_big_redstone.microchip.object.logic.register.LogicTypeDeferredRegister;
 import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelector;
 import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelectorConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.sequencer.LogicSequencer;
@@ -51,13 +51,13 @@ import net.swedz.little_big_redstone.microchip.object.logic.tag.LogicTagConfig;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 public final class LBRLogicTypes
 {
 	private static final LogicTypeDeferredRegister REGISTRY = new LogicTypeDeferredRegister(LBR.ID);
 	
-	private static final Set<LogicType> VALUES = Sets.newHashSet();
+	private static final List<LogicType> VALUES = Lists.newArrayList();
 	
 	private static final MutableInt SYMBOL = new MutableInt();
 	
@@ -83,9 +83,9 @@ public final class LBRLogicTypes
 	public static final DeferredLogicType<LogicType> T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
 	public static final DeferredLogicType<LogicType> RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
 	
-	public static Set<LogicType> values()
+	public static List<LogicType> values()
 	{
-		return Collections.unmodifiableSet(VALUES);
+		return Collections.unmodifiableList(VALUES);
 	}
 	
 	private static <T extends LogicComponent<T, C>, C extends LogicConfig> DeferredLogicType<LogicType> register(

--- a/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/LBRLogicTypes.java
@@ -5,12 +5,11 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.registries.DeferredHolder;
-import net.neoforged.neoforge.registries.DeferredRegister;
+import net.swedz.little_big_redstone.microchip.object.logic.register.DeferredLogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicFactory;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
+import net.swedz.little_big_redstone.microchip.object.logic.register.LogicTypeDeferredRegister;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculator;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparator;
@@ -56,40 +55,40 @@ import java.util.Set;
 
 public final class LBRLogicTypes
 {
-	private static final DeferredRegister<LogicType> REGISTRY = DeferredRegister.create(LogicTypes.REGISTRY, LBR.ID);
+	private static final LogicTypeDeferredRegister REGISTRY = new LogicTypeDeferredRegister(LBR.ID);
 	
 	private static final Set<LogicType> VALUES = Sets.newHashSet();
 	
 	private static final MutableInt SYMBOL = new MutableInt();
 	
-	public static final DeferredHolder<LogicType, LogicType> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType, LogicType> IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType, LogicType> NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
 	
-	public static final DeferredHolder<LogicType, LogicType> SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
-	public static final DeferredHolder<LogicType, LogicType> RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> T_FLIP_FLOP     = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
+	public static final DeferredLogicType<LogicType> RS_NOR_LATCH    = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
 	
 	public static Set<LogicType> values()
 	{
 		return Collections.unmodifiableSet(VALUES);
 	}
 	
-	private static <T extends LogicComponent<T, C>, C extends LogicConfig> DeferredHolder<LogicType, LogicType> register(
+	private static <T extends LogicComponent<T, C>, C extends LogicConfig> DeferredLogicType<LogicType> register(
 			String name,
 			String englishName,
 			MapCodec<T> codec,
@@ -116,7 +115,7 @@ public final class LBRLogicTypes
 		return REGISTRY.register(name, () -> type);
 	}
 	
-	private static <T extends LogicGate<T, C>, C extends LogicConfig> DeferredHolder<LogicType, LogicType> registerGate(
+	private static <T extends LogicGate<T, C>, C extends LogicConfig> DeferredLogicType<LogicType> registerGate(
 			String id,
 			String englishName,
 			MapCodec<T> codec,

--- a/src/main/java/net/swedz/little_big_redstone/client/item/LogicItemRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/client/item/LogicItemRenderer.java
@@ -13,7 +13,6 @@ import net.neoforged.neoforge.client.NeoForgeRenderTypes;
 import net.neoforged.neoforge.client.RenderTypeGroup;
 import net.neoforged.neoforge.client.model.CompositeModel;
 import net.neoforged.neoforge.client.model.data.ModelData;
-import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRClientRenderTypes;
 import net.swedz.little_big_redstone.LBRComponents;
 import net.swedz.little_big_redstone.client.model.logic.LogicBakedModel;
@@ -45,7 +44,7 @@ public final class LogicItemRenderer extends BlockEntityWithoutLevelRenderer
 	{
 		var logicConfig = stack.get(LBRComponents.LOGIC_CONFIG);
 		var logicColor = Optional.ofNullable(stack.get(LBRComponents.LOGIC_COLOR));
-		var model = ((LogicBakedModel) Minecraft.getInstance().getModelManager().getModel(ModelResourceLocation.inventory(LBR.id(logicConfig.type().id())))).getModel(logicColor);
+		var model = ((LogicBakedModel) Minecraft.getInstance().getModelManager().getModel(ModelResourceLocation.inventory(logicConfig.type().id()))).getModel(logicColor);
 		
 		int index = 0;
 		for(var modelLayer : model.getRenderPasses(stack, false))

--- a/src/main/java/net/swedz/little_big_redstone/client/model/logic/LogicBakingModelData.java
+++ b/src/main/java/net/swedz/little_big_redstone/client/model/logic/LogicBakingModelData.java
@@ -15,7 +15,6 @@ import net.neoforged.neoforge.client.model.generators.CustomLoaderBuilder;
 import net.neoforged.neoforge.client.model.generators.ModelBuilder;
 import net.neoforged.neoforge.client.model.generators.ModelProvider;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
-import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.tesseract.api.Assert;
 import net.swedz.tesseract.neoforge.helper.CodecHelper;
@@ -38,7 +37,7 @@ public final class LogicBakingModelData
 	
 	public static LogicBakingModelData get(LogicType<?, ?> type)
 	{
-		return ((LogicBakedModel) Minecraft.getInstance().getModelManager().getModel(ModelResourceLocation.inventory(LBR.id(type.id())))).getData();
+		return ((LogicBakedModel) Minecraft.getInstance().getModelManager().getModel(ModelResourceLocation.inventory(type.id()))).getData();
 	}
 	
 	private final Map<DyeColor, LogicModelColorSet> colorPalette;

--- a/src/main/java/net/swedz/little_big_redstone/client/model/logic/LogicBakingModelData.java
+++ b/src/main/java/net/swedz/little_big_redstone/client/model/logic/LogicBakingModelData.java
@@ -35,7 +35,7 @@ public final class LogicBakingModelData
 			)
 			.apply(instance, LogicBakingModelData::new));
 	
-	public static LogicBakingModelData get(LogicType<?, ?> type)
+	public static LogicBakingModelData get(LogicType type)
 	{
 		return ((LogicBakedModel) Minecraft.getInstance().getModelManager().getModel(ModelResourceLocation.inventory(type.id()))).getData();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/LogicComponentFontDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/LogicComponentFontDatagenProvider.java
@@ -2,7 +2,7 @@ package net.swedz.little_big_redstone.datagen.client.provider;
 
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.swedz.little_big_redstone.LBR;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.tesseract.neoforge.helper.datagen.FontDatagenProvider;
 
 public final class LogicComponentFontDatagenProvider extends FontDatagenProvider
@@ -15,16 +15,16 @@ public final class LogicComponentFontDatagenProvider extends FontDatagenProvider
 	@Override
 	protected void addProviders()
 	{
-		for(var type : LogicTypes.values())
+		for(var type : LBRLogicTypes.values())
 		{
 			int height = 8;
 			int ascent = 7;
-			if(type == LogicTypes.DEBUGGER)
+			if(type.is(LBRLogicTypes.DEBUGGER))
 			{
 				height = 10;
 				ascent = 8;
 			}
-			this.addBitmap(type.symbol(), LBR.id("font/logic/" + type.id()), height, ascent);
+			this.addBitmap(type.symbol(), type.id().withPrefix("font/logic/"), height, ascent);
 		}
 	}
 }

--- a/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
@@ -8,14 +8,17 @@ import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRColors;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.client.model.logic.LogicBakingModelData;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorMode;
+import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 {
@@ -28,37 +31,52 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 	
 	private void registerLogicModels()
 	{
-		this.logicComponent(LogicTypes.DEBUGGER, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.DEBUGGER, BackgroundType.SQUARE, true);
 		
-		this.logicComponent(LogicTypes.IO, BackgroundType.CIRCLE, false, (b) -> b
-				.boardTexture("input", LBR.id("logic/io_input"))
-				.boardTexture("output", LBR.id("logic/io_output")));
-		this.logicComponent(LogicTypes.READER, BackgroundType.CIRCLE, true);
-		this.logicComponent(LogicTypes.TAG, BackgroundType.CIRCLE, true);
+		this.logicComponent(
+				LBRLogicTypes.IO, BackgroundType.CIRCLE, false,
+				(b) -> b
+						.boardTexture("input", LBR.id("logic/io_input"))
+						.boardTexture("output", LBR.id("logic/io_output"))
+		);
+		this.logicComponent(LBRLogicTypes.READER, BackgroundType.CIRCLE, true);
+		this.logicComponent(LBRLogicTypes.TAG, BackgroundType.CIRCLE, true);
 		
-		this.logicComponent(LogicTypes.NOT, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.AND, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.NAND, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.OR, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.NOR, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.XOR, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.NOT, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.AND, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.NAND, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.OR, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.NOR, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.XOR, BackgroundType.SQUARE, true);
 		
-		this.logicComponent(LogicTypes.SEQUENCER, BackgroundType.SQUARE, false, (b) -> b
-				.boardTexture("progress", LBR.id("logic/sequencer")));
-		this.logicComponent(LogicTypes.PULSE_THROTTLER, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.SELECTOR, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.RANDOMIZER, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.COMPARATOR, BackgroundType.SQUARE, true);
-		this.logicComponent(LogicTypes.CALCULATOR, BackgroundType.SQUARE, false, (b) -> b
-				.boardTexture(LogicCalculatorMode.ADDITION.textureKey(), LBR.id("logic/calculator_addition"))
-				.boardTexture(LogicCalculatorMode.SUBTRACTION.textureKey(), LBR.id("logic/calculator_subtraction")));
+		this.logicComponent(
+				LBRLogicTypes.SEQUENCER, BackgroundType.SQUARE, false,
+				(b) -> b
+						.boardTexture("progress", LBR.id("logic/sequencer"))
+		);
+		this.logicComponent(LBRLogicTypes.PULSE_THROTTLER, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.SELECTOR, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.RANDOMIZER, BackgroundType.SQUARE, true);
+		this.logicComponent(LBRLogicTypes.COMPARATOR, BackgroundType.SQUARE, true);
+		this.logicComponent(
+				LBRLogicTypes.CALCULATOR, BackgroundType.SQUARE, false,
+				(b) -> b
+						.boardTexture(LogicCalculatorMode.ADDITION.textureKey(), LBR.id("logic/calculator_addition"))
+						.boardTexture(LogicCalculatorMode.SUBTRACTION.textureKey(), LBR.id("logic/calculator_subtraction"))
+		);
 		
-		this.logicComponent(LogicTypes.T_FLIP_FLOP, BackgroundType.SQUARE, false, (b) -> b
-				.boardTexture("on", LBR.id("logic/t_flip_flop_on"))
-				.boardTexture("off", LBR.id("logic/t_flip_flop_off")));
-		this.logicComponent(LogicTypes.RS_NOR_LATCH, BackgroundType.SQUARE, false, (b) -> b
-				.boardTexture("on", LBR.id("logic/rs_nor_latch_on"))
-				.boardTexture("off", LBR.id("logic/rs_nor_latch_off")));
+		this.logicComponent(
+				LBRLogicTypes.T_FLIP_FLOP, BackgroundType.SQUARE, false,
+				(b) -> b
+						.boardTexture("on", LBR.id("logic/t_flip_flop_on"))
+						.boardTexture("off", LBR.id("logic/t_flip_flop_off"))
+		);
+		this.logicComponent(
+				LBRLogicTypes.RS_NOR_LATCH, BackgroundType.SQUARE, false,
+				(b) -> b
+						.boardTexture("on", LBR.id("logic/rs_nor_latch_on"))
+						.boardTexture("off", LBR.id("logic/rs_nor_latch_off"))
+		);
 	}
 	
 	@Override
@@ -71,7 +89,7 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 	private void assertAllTypesAreGenerated()
 	{
 		boolean missing = false;
-		for(var type : LogicTypes.values())
+		for(var type : LBRLogicTypes.values())
 		{
 			if(!generated.contains(type))
 			{
@@ -118,23 +136,29 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 		}
 	}
 	
-	private void logicComponent(LogicType<?, ?> type, BackgroundType backgroundType, boolean icon, Consumer<LogicBakingModelData.Builder<?>> also)
+	private <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
+			Supplier<LogicType<L, C>> entry,
+			BackgroundType backgroundType,
+			boolean icon,
+			Consumer<LogicBakingModelData.Builder<?>> also
+	)
 	{
+		var type = entry.get();
 		generated.add(type);
-		String id = type.id();
-		this.getBuilder("item/%s".formatted(id))
+		var name = type.id().getPath();
+		this.getBuilder("item/%s".formatted(name))
 				.parent(new ModelFile.UncheckedModelFile("item/generated"))
 				.customLoader((parent, efh) ->
 				{
 					var builder = LogicBakingModelData.builder(parent, efh)
 							.itemTexture("background", backgroundType.itemBackground())
 							.itemTexture("border", backgroundType.itemBorder())
-							.itemTexture("icon", LBR.id("item/logic/%s".formatted(id)))
+							.itemTexture("icon", LBR.id("item/logic/%s".formatted(name)))
 							.boardTexture("background", backgroundType.boardBackground())
 							.boardTexture("border", backgroundType.boardBorder());
 					if(icon)
 					{
-						builder.boardTexture("icon", LBR.id("logic/%s".formatted(id)));
+						builder.boardTexture("icon", LBR.id("logic/%s".formatted(name)));
 					}
 					for(var color : DyeColor.values())
 					{
@@ -150,7 +174,11 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 				.end();
 	}
 	
-	private void logicComponent(LogicType<?, ?> type, BackgroundType backgroundType, boolean icon)
+	private <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
+			Supplier<LogicType<L, C>> type,
+			BackgroundType backgroundType,
+			boolean icon
+	)
 	{
 		this.logicComponent(type, backgroundType, icon, null);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
@@ -10,10 +10,8 @@ import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRColors;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.client.model.logic.LogicBakingModelData;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorMode;
-import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
 import java.util.Locale;
 import java.util.Set;
@@ -22,7 +20,7 @@ import java.util.function.Supplier;
 
 public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 {
-	private final Set<LogicType<?, ?>> generated = Sets.newHashSet();
+	private final Set<LogicType> generated = Sets.newHashSet();
 	
 	public LogicItemModelsDatagenProvider(GatherDataEvent event)
 	{
@@ -136,8 +134,8 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 		}
 	}
 	
-	private <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
-			Supplier<LogicType<L, C>> entry,
+	private void logicComponent(
+			Supplier<LogicType> entry,
 			BackgroundType backgroundType,
 			boolean icon,
 			Consumer<LogicBakingModelData.Builder<?>> also
@@ -174,8 +172,8 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 				.end();
 	}
 	
-	private <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
-			Supplier<LogicType<L, C>> type,
+	private void logicComponent(
+			Supplier<LogicType> type,
 			BackgroundType backgroundType,
 			boolean icon
 	)

--- a/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/client/provider/models/LogicItemModelsDatagenProvider.java
@@ -173,12 +173,12 @@ public final class LogicItemModelsDatagenProvider extends ItemModelProvider
 	}
 	
 	private void logicComponent(
-			Supplier<LogicType> type,
+			Supplier<LogicType> entry,
 			BackgroundType backgroundType,
 			boolean icon
 	)
 	{
-		this.logicComponent(type, backgroundType, icon, null);
+		this.logicComponent(entry, backgroundType, icon, null);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/datagen/server/provider/recipes/LogicRecipesDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/server/provider/recipes/LogicRecipesDatagenProvider.java
@@ -12,12 +12,15 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRItems;
+import net.swedz.little_big_redstone.LBRLogicTypes;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
+import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.compat.vanilla.recipe.ShapedRecipeBuilder;
 
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public final class LogicRecipesDatagenProvider extends RecipeProvider
 {
@@ -38,8 +41,14 @@ public final class LogicRecipesDatagenProvider extends RecipeProvider
 			'P', Either.right(Tags.Items.ENDER_PEARLS)
 	);
 	
-	private static void logicComponent(RecipeOutput output, LogicType<?, ?> type, Consumer<ShapedRecipeBuilder> action)
+	private static <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
+			RecipeOutput output,
+			Supplier<LogicType<L, C>> typeEntry,
+			Consumer<ShapedRecipeBuilder> action
+	)
 	{
+		var type = typeEntry.get();
+		
 		var builder = new ShapedRecipeBuilder()
 				.output(type.item(), 1);
 		
@@ -58,99 +67,167 @@ public final class LogicRecipesDatagenProvider extends RecipeProvider
 			}
 		}
 		
-		builder.offerTo(output, LBR.id("logic/%s".formatted(type.id())));
+		builder.offerTo(output, LBR.id("logic/%s".formatted(type.id().getPath())));
 	}
 	
 	@Override
 	protected void buildRecipes(RecipeOutput output, HolderLookup.Provider registries)
 	{
-		logicComponent(output, LogicTypes.IO, (b) -> b
-				.pattern("R  ")
-				.pattern(" r ")
-				.pattern("  R"));
+		logicComponent(
+				output,
+				LBRLogicTypes.IO,
+				(b) -> b
+						.pattern("R  ")
+						.pattern(" r ")
+						.pattern("  R")
+		);
 		
-		logicComponent(output, LogicTypes.READER, (b) -> b
-				.pattern("R  ")
-				.pattern("QrR")
-				.pattern("R  "));
+		logicComponent(
+				output,
+				LBRLogicTypes.READER,
+				(b) -> b
+						.pattern("R  ")
+						.pattern("QrR")
+						.pattern("R  ")
+		);
 		
-		logicComponent(output, LogicTypes.TAG, (b) -> b
-				.pattern("PQG")
-				.pattern("PrR")
-				.pattern("PQG"));
+		logicComponent(
+				output,
+				LBRLogicTypes.TAG,
+				(b) -> b
+						.pattern("PQG")
+						.pattern("PrR")
+						.pattern("PQG")
+		);
 		
-		logicComponent(output, LogicTypes.NOT, (b) -> b
-				.pattern("RrT"));
+		logicComponent(
+				output,
+				LBRLogicTypes.NOT,
+				(b) -> b
+						.pattern("RrT")
+		);
 		
-		logicComponent(output, LogicTypes.AND, (b) -> b
-				.pattern("T  ")
-				.pattern("RrT")
-				.pattern("T  "));
+		logicComponent(
+				output,
+				LBRLogicTypes.AND,
+				(b) -> b
+						.pattern("T  ")
+						.pattern("RrT")
+						.pattern("T  ")
+		);
 		
-		logicComponent(output, LogicTypes.NAND, (b) -> b
-				.pattern("T  ")
-				.pattern("RrR")
-				.pattern("T  "));
+		logicComponent(
+				output,
+				LBRLogicTypes.NAND,
+				(b) -> b
+						.pattern("T  ")
+						.pattern("RrR")
+						.pattern("T  ")
+		);
 		
-		logicComponent(output, LogicTypes.OR, (b) -> b
-				.pattern("R  ")
-				.pattern("RrR")
-				.pattern("R  "));
+		logicComponent(
+				output,
+				LBRLogicTypes.OR,
+				(b) -> b
+						.pattern("R  ")
+						.pattern("RrR")
+						.pattern("R  ")
+		);
 		
-		logicComponent(output, LogicTypes.NOR, (b) -> b
-				.pattern("R  ")
-				.pattern("RrT")
-				.pattern("R  "));
+		logicComponent(
+				output,
+				LBRLogicTypes.NOR,
+				(b) -> b
+						.pattern("R  ")
+						.pattern("RrT")
+						.pattern("R  ")
+		);
 		
-		logicComponent(output, LogicTypes.XOR, (b) -> b
-				.pattern("1  ")
-				.pattern("Rr2")
-				.pattern("2  ")
-				.define('1', LBRItems.valueOf("and_gate"))
-				.define('2', LBRItems.valueOf("nor_gate")));
+		logicComponent(
+				output,
+				LBRLogicTypes.XOR,
+				(b) -> b
+						.pattern("1  ")
+						.pattern("Rr2")
+						.pattern("2  ")
+						.define('1', LBRItems.valueOf("and_gate"))
+						.define('2', LBRItems.valueOf("nor_gate"))
+		);
 		
-		logicComponent(output, LogicTypes.SEQUENCER, (b) -> b
-				.pattern("GGG")
-				.pattern("ErR")
-				.pattern("GGG"));
+		logicComponent(
+				output,
+				LBRLogicTypes.SEQUENCER,
+				(b) -> b
+						.pattern("GGG")
+						.pattern("ErR")
+						.pattern("GGG")
+		);
 		
-		logicComponent(output, LogicTypes.PULSE_THROTTLER, (b) -> b
-				.pattern("RrR")
-				.pattern(" p "));
+		logicComponent(
+				output,
+				LBRLogicTypes.PULSE_THROTTLER,
+				(b) -> b
+						.pattern("RrR")
+						.pattern(" p ")
+		);
 		
-		logicComponent(output, LogicTypes.SELECTOR, (b) -> b
-				.pattern("EGR")
-				.pattern("ErR")
-				.pattern("EGR"));
+		logicComponent(
+				output,
+				LBRLogicTypes.SELECTOR,
+				(b) -> b
+						.pattern("EGR")
+						.pattern("ErR")
+						.pattern("EGR")
+		);
 		
-		logicComponent(output, LogicTypes.RANDOMIZER, (b) -> b
-				.pattern("GGR")
-				.pattern("1rR")
-				.pattern("GGR")
-				.define('1', Items.DROPPER));
+		logicComponent(
+				output,
+				LBRLogicTypes.RANDOMIZER,
+				(b) -> b
+						.pattern("GGR")
+						.pattern("1rR")
+						.pattern("GGR")
+						.define('1', Items.DROPPER)
+		);
 		
-		logicComponent(output, LogicTypes.COMPARATOR, (b) -> b
-				.pattern("RT ")
-				.pattern("QrT")
-				.pattern("RT "));
+		logicComponent(
+				output,
+				LBRLogicTypes.COMPARATOR,
+				(b) -> b
+						.pattern("RT ")
+						.pattern("QrT")
+						.pattern("RT ")
+		);
 		
-		logicComponent(output, LogicTypes.CALCULATOR, (b) -> b
-				.pattern("CCG")
-				.pattern("RrQ")
-				.pattern("CCG"));
+		logicComponent(
+				output,
+				LBRLogicTypes.CALCULATOR,
+				(b) -> b
+						.pattern("CCG")
+						.pattern("RrQ")
+						.pattern("CCG")
+		);
 		
-		logicComponent(output, LogicTypes.T_FLIP_FLOP, (b) -> b
-				.pattern("1  ")
-				.pattern("2rR")
-				.pattern("1  ")
-				.define('1', LBRItems.valueOf("nand_gate"))
-				.define('2', LBRItems.valueOf("rs_nor_latch")));
+		logicComponent(
+				output,
+				LBRLogicTypes.T_FLIP_FLOP,
+				(b) -> b
+						.pattern("1  ")
+						.pattern("2rR")
+						.pattern("1  ")
+						.define('1', LBRItems.valueOf("nand_gate"))
+						.define('2', LBRItems.valueOf("rs_nor_latch"))
+		);
 		
-		logicComponent(output, LogicTypes.RS_NOR_LATCH, (b) -> b
-				.pattern("R1 ")
-				.pattern(" rR")
-				.pattern("R1 ")
-				.define('1', LBRItems.valueOf("nor_gate")));
+		logicComponent(
+				output,
+				LBRLogicTypes.RS_NOR_LATCH,
+				(b) -> b
+						.pattern("R1 ")
+						.pattern(" rR")
+						.pattern("R1 ")
+						.define('1', LBRItems.valueOf("nor_gate"))
+		);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/datagen/server/provider/recipes/LogicRecipesDatagenProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/datagen/server/provider/recipes/LogicRecipesDatagenProvider.java
@@ -13,9 +13,7 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRItems;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.compat.vanilla.recipe.ShapedRecipeBuilder;
 
 import java.util.Map;
@@ -41,9 +39,9 @@ public final class LogicRecipesDatagenProvider extends RecipeProvider
 			'P', Either.right(Tags.Items.ENDER_PEARLS)
 	);
 	
-	private static <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void logicComponent(
+	private static void logicComponent(
 			RecipeOutput output,
-			Supplier<LogicType<L, C>> typeEntry,
+			Supplier<LogicType> typeEntry,
 			Consumer<ShapedRecipeBuilder> action
 	)
 	{

--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/LogicConfigMenu.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/LogicConfigMenu.java
@@ -22,8 +22,8 @@ public final class LogicConfigMenu extends AbstractContainerMenu
 	
 	private final Supplier<Boolean> validChecker;
 	
-	private final DyeColor       color;
-	private final LogicConfig<?> logicConfig;
+	private final DyeColor    color;
+	private final LogicConfig logicConfig;
 	
 	public LogicConfigMenu(
 			int containerId,
@@ -32,7 +32,7 @@ public final class LogicConfigMenu extends AbstractContainerMenu
 			LogicConfigReference reference,
 			Supplier<Boolean> validChecker,
 			DyeColor color,
-			LogicConfig<?> logicConfig
+			LogicConfig logicConfig
 	)
 	{
 		super(LBRMenus.LOGIC_CONFIG.get(), containerId);
@@ -69,12 +69,12 @@ public final class LogicConfigMenu extends AbstractContainerMenu
 		return color;
 	}
 	
-	public LogicConfig<?> logicConfig()
+	public LogicConfig logicConfig()
 	{
 		return logicConfig;
 	}
 	
-	public void save(Player player, LogicConfig<?> config)
+	public void save(Player player, LogicConfig config)
 	{
 		reference.save(player, config);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/LogicConfigScreen.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/LogicConfigScreen.java
@@ -68,7 +68,7 @@ public final class LogicConfigScreen extends AbstractContainerScreen<LogicConfig
 		}
 	}
 	
-	private LogicConfig<?> logicConfig()
+	private LogicConfig logicConfig()
 	{
 		return logicConfigMenuProvider.config();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/HeldItemLogicConfigReference.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/HeldItemLogicConfigReference.java
@@ -12,7 +12,7 @@ public record HeldItemLogicConfigReference(
 ) implements LogicConfigReference
 {
 	@Override
-	public void save(Player player, LogicConfig<?> config)
+	public void save(Player player, LogicConfig config)
 	{
 		var stack = player.getItemInHand(hand);
 		var stackLogicConfig = stack.get(LBRComponents.LOGIC_CONFIG);

--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/LogicConfigReference.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/LogicConfigReference.java
@@ -8,7 +8,7 @@ public interface LogicConfigReference
 	/**
 	 * Saves the logic config on the server.
 	 */
-	void save(Player player, LogicConfig<?> config);
+	void save(Player player, LogicConfig config);
 	
 	/**
 	 * Closes the menu for the player with no changes being saved on the server.

--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/MicrochipLogicConfigReference.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/MicrochipLogicConfigReference.java
@@ -19,7 +19,7 @@ public record MicrochipLogicConfigReference(
 ) implements LogicConfigReference
 {
 	@Override
-	public void save(Player player, LogicConfig<?> config)
+	public void save(Player player, LogicConfig config)
 	{
 		var playerName = player.getGameProfile().getName();
 		

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/MicrochipScreen.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/MicrochipScreen.java
@@ -224,7 +224,7 @@ public final class MicrochipScreen extends AbstractContainerScreen<MicrochipMenu
 	{
 	}
 	
-	private void renderCarriedWires(TesseractGuiGraphics graphics, int logicX, int logicY, LogicRenderer.Context context, LogicConfig<?> config, Optional<DyeColor> color)
+	private void renderCarriedWires(TesseractGuiGraphics graphics, int logicX, int logicY, LogicRenderer.Context context, LogicConfig config, Optional<DyeColor> color)
 	{
 		if(menu.getCarriedWires() != null)
 		{
@@ -253,7 +253,7 @@ public final class MicrochipScreen extends AbstractContainerScreen<MicrochipMenu
 		}
 	}
 	
-	private <C extends LogicConfig<C>> void renderCarriedLogic(TesseractGuiGraphics graphics, int logicX, int logicY, LogicRenderer.Context context, C config, Optional<DyeColor> logicColor)
+	private void renderCarriedLogic(TesseractGuiGraphics graphics, int logicX, int logicY, LogicRenderer.Context context, LogicConfig config, Optional<DyeColor> logicColor)
 	{
 		var microchip = menu.microchip();
 		var size = microchip.size();

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderer.java
@@ -14,7 +14,7 @@ import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 import java.util.Optional;
 import java.util.function.Function;
 
-public abstract class LogicRenderer<L extends LogicComponent<L, C>, C extends LogicConfig<C>>
+public abstract class LogicRenderer<L extends LogicComponent<L, C>, C extends LogicConfig>
 {
 	public static final ResourceLocation PORT_INPUT  = LBR.id("textures/logic/port_input.png");
 	public static final ResourceLocation PORT_OUTPUT = LBR.id("textures/logic/port_output.png");
@@ -107,7 +107,7 @@ public abstract class LogicRenderer<L extends LogicComponent<L, C>, C extends Lo
 			boolean showPorts, boolean hasSelectedPort, boolean isCarryingWire
 	)
 	{
-		public static Context create(Optional<DyeColor> logicColor, DyeColor menuColor, LogicType<?, ?> type, boolean showPorts, boolean hasSelectedPort, boolean isCarryingWire)
+		public static Context create(Optional<DyeColor> logicColor, DyeColor menuColor, LogicType type, boolean showPorts, boolean hasSelectedPort, boolean isCarryingWire)
 		{
 			var modelData = LogicBakingModelData.get(type);
 			return new Context(
@@ -119,7 +119,7 @@ public abstract class LogicRenderer<L extends LogicComponent<L, C>, C extends Lo
 			);
 		}
 		
-		public static Context create(DyeColor logicColor, DyeColor menuColor, LogicType<?, ?> type, boolean showPorts, boolean hasSelectedPort, boolean isCarryingWire)
+		public static Context create(DyeColor logicColor, DyeColor menuColor, LogicType type, boolean showPorts, boolean hasSelectedPort, boolean isCarryingWire)
 		{
 			return create(Optional.ofNullable(logicColor), menuColor, type, showPorts, hasSelectedPort, isCarryingWire);
 		}

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRendererProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRendererProvider.java
@@ -3,7 +3,7 @@ package net.swedz.little_big_redstone.gui.microchip.logic;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
-public interface LogicRendererProvider<L extends LogicComponent<L, C>, C extends LogicConfig<C>>
+public interface LogicRendererProvider<L extends LogicComponent<L, C>, C extends LogicConfig>
 {
 	LogicRenderer<L, C> create();
 }

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderers.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderers.java
@@ -2,6 +2,9 @@ package net.swedz.little_big_redstone.gui.microchip.logic;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.gui.microchip.logic.renderer.CalculatorLogicRenderer;
 import net.swedz.little_big_redstone.gui.microchip.logic.renderer.IORenderer;
 import net.swedz.little_big_redstone.gui.microchip.logic.renderer.OnOffLogicRenderer;
@@ -9,7 +12,6 @@ import net.swedz.little_big_redstone.gui.microchip.logic.renderer.SequencerRende
 import net.swedz.little_big_redstone.gui.microchip.logic.renderer.SimpleLogicRenderer;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 
@@ -17,34 +19,34 @@ import java.util.Map;
 
 public final class LogicRenderers
 {
-	private static final Map<LogicType<?, ?>, LogicRendererProvider<?, ?>> PROVIDERS = Maps.newConcurrentMap();
+	private static final Map<ResourceLocation, LogicRendererProvider<?, ?>> PROVIDERS = Maps.newConcurrentMap();
 	
-	private static Map<LogicType<?, ?>, LogicRenderer<?, ?>> RENDERERS = Map.of();
+	private static Map<ResourceLocation, LogicRenderer<?, ?>> RENDERERS = Map.of();
 	
 	static
 	{
-		register(LogicTypes.DEBUGGER, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.DEBUGGER, SimpleLogicRenderer::new);
 		
-		register(LogicTypes.IO, IORenderer::new);
-		register(LogicTypes.READER, SimpleLogicRenderer::new);
-		register(LogicTypes.TAG, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.IO, IORenderer::new);
+		register(LBRLogicTypes.READER, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.TAG, SimpleLogicRenderer::new);
 		
-		register(LogicTypes.NOT, SimpleLogicRenderer::new);
-		register(LogicTypes.AND, SimpleLogicRenderer::new);
-		register(LogicTypes.NAND, SimpleLogicRenderer::new);
-		register(LogicTypes.OR, SimpleLogicRenderer::new);
-		register(LogicTypes.NOR, SimpleLogicRenderer::new);
-		register(LogicTypes.XOR, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.NOT, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.AND, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.NAND, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.OR, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.NOR, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.XOR, SimpleLogicRenderer::new);
 		
-		register(LogicTypes.SEQUENCER, SequencerRenderer::new);
-		register(LogicTypes.PULSE_THROTTLER, SimpleLogicRenderer::new);
-		register(LogicTypes.SELECTOR, SimpleLogicRenderer::new);
-		register(LogicTypes.RANDOMIZER, SimpleLogicRenderer::new);
-		register(LogicTypes.COMPARATOR, SimpleLogicRenderer::new);
-		register(LogicTypes.CALCULATOR, CalculatorLogicRenderer::new);
+		register(LBRLogicTypes.SEQUENCER, SequencerRenderer::new);
+		register(LBRLogicTypes.PULSE_THROTTLER, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.SELECTOR, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.RANDOMIZER, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.COMPARATOR, SimpleLogicRenderer::new);
+		register(LBRLogicTypes.CALCULATOR, CalculatorLogicRenderer::new);
 		
-		register(LogicTypes.T_FLIP_FLOP, OnOffLogicRenderer::new);
-		register(LogicTypes.RS_NOR_LATCH, OnOffLogicRenderer::new);
+		register(LBRLogicTypes.T_FLIP_FLOP, OnOffLogicRenderer::new);
+		register(LBRLogicTypes.RS_NOR_LATCH, OnOffLogicRenderer::new);
 	}
 	
 	public static void init()
@@ -52,23 +54,23 @@ public final class LogicRenderers
 		RENDERERS = createRenderers();
 	}
 	
-	private static <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void register(LogicType<L, C> type, LogicRendererProvider<L, C> provider)
+	private static <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void register(DeferredHolder<LogicType<?, ?>, LogicType<L, C>> type, LogicRendererProvider<L, C> provider)
 	{
-		PROVIDERS.put(type, provider);
+		PROVIDERS.put(type.getId(), provider);
 	}
 	
-	private static Map<LogicType<?, ?>, LogicRenderer<?, ?>> createRenderers()
+	private static Map<ResourceLocation, LogicRenderer<?, ?>> createRenderers()
 	{
-		ImmutableMap.Builder<LogicType<?, ?>, LogicRenderer<?, ?>> builder = ImmutableMap.builder();
-		PROVIDERS.forEach((type, provider) ->
+		ImmutableMap.Builder<ResourceLocation, LogicRenderer<?, ?>> builder = ImmutableMap.builder();
+		PROVIDERS.forEach((id, provider) ->
 		{
 			try
 			{
-				builder.put(type, provider.create());
+				builder.put(id, provider.create());
 			}
 			catch (Exception ex)
 			{
-				throw new IllegalStateException("Failed to create logic renderer for " + type.id(), ex);
+				throw new IllegalStateException("Failed to create logic renderer for " + id, ex);
 			}
 		});
 		return builder.build();
@@ -76,7 +78,7 @@ public final class LogicRenderers
 	
 	public static void render(LogicRenderer.Context context, TesseractGuiGraphics graphics, LogicComponent<?, ?> component, int x, int y)
 	{
-		LogicRenderer renderer = RENDERERS.get(component.type());
+		LogicRenderer renderer = RENDERERS.get(component.type().id());
 		if(renderer != null)
 		{
 			renderer.render(context, graphics, component, x, y);

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderers.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderers.java
@@ -12,7 +12,6 @@ import net.swedz.little_big_redstone.gui.microchip.logic.renderer.SequencerRende
 import net.swedz.little_big_redstone.gui.microchip.logic.renderer.SimpleLogicRenderer;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 
 import java.util.Map;
@@ -54,7 +53,10 @@ public final class LogicRenderers
 		RENDERERS = createRenderers();
 	}
 	
-	private static <L extends LogicComponent<L, C>, C extends LogicConfig<C>> void register(DeferredHolder<LogicType<?, ?>, LogicType<L, C>> type, LogicRendererProvider<L, C> provider)
+	private static void register(
+			DeferredHolder<LogicType, LogicType> type,
+			LogicRendererProvider provider
+	)
 	{
 		PROVIDERS.put(type.getId(), provider);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/renderer/OnOffLogicRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/renderer/OnOffLogicRenderer.java
@@ -7,7 +7,7 @@ import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 
-public final class OnOffLogicRenderer<L extends LogicComponent<L, C>, C extends LogicConfig<C>> extends LogicRenderer<L, C>
+public final class OnOffLogicRenderer<L extends LogicComponent<L, C>, C extends LogicConfig> extends LogicRenderer<L, C>
 {
 	@Override
 	public void render(Context context, TesseractGuiGraphics graphics, L component, int x, int y)

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/renderer/SimpleLogicRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/renderer/SimpleLogicRenderer.java
@@ -7,7 +7,7 @@ import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 
-public final class SimpleLogicRenderer<G extends LogicComponent<G, C>, C extends LogicConfig<C>> extends LogicRenderer<G, C>
+public final class SimpleLogicRenderer<G extends LogicComponent<G, C>, C extends LogicConfig> extends LogicRenderer<G, C>
 {
 	@Override
 	public void render(Context context, TesseractGuiGraphics graphics, G component, int x, int y)

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/wire/WireMetadata.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/wire/WireMetadata.java
@@ -16,7 +16,7 @@ public record WireMetadata(
 		int argb
 )
 {
-	private static int getColor(LogicType<?, ?> output, Optional<DyeColor> color, DyeColor fallback)
+	private static int getColor(LogicType output, Optional<DyeColor> color, DyeColor fallback)
 	{
 		return LogicBakingModelData.get(output).getColorSet(color, fallback).foreground();
 	}
@@ -39,7 +39,7 @@ public record WireMetadata(
 		return of(microchip, color, wire.output(), hovered);
 	}
 	
-	public static WireMetadata carried(Microchip microchip, DyeColor fallbackColor, int carriedComponentSlot, LogicType<?, ?> type, Optional<DyeColor> logicColor, Wire wire)
+	public static WireMetadata carried(Microchip microchip, DyeColor fallbackColor, int carriedComponentSlot, LogicType type, Optional<DyeColor> logicColor, Wire wire)
 	{
 		boolean isOutput = wire.output().slot() == carriedComponentSlot;
 		var outputLogic = isOutput ? null : microchip.components().get(wire.output().slot());

--- a/src/main/java/net/swedz/little_big_redstone/guide/LBRGuide.java
+++ b/src/main/java/net/swedz/little_big_redstone/guide/LBRGuide.java
@@ -8,6 +8,7 @@ import guideme.compiler.tags.MdxAttrs;
 import guideme.document.LytErrorSink;
 import guideme.libs.mdast.mdx.model.MdxJsxElementFields;
 import guideme.scene.ImplicitAnnotationStrategy;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.guide.tags.block.FloatingBoxTagCompiler;
@@ -85,7 +86,12 @@ public final class LBRGuide
 		{
 			try
 			{
-				return LogicTypes.get(logicId.toLowerCase());
+				logicId = logicId.toLowerCase();
+				return LogicTypes.REGISTRY.get(
+						ResourceLocation.isValidPath(logicId) ?
+								LBR.id(logicId) :
+								ResourceLocation.parse(logicId)
+				);
 			}
 			catch(Exception ignored)
 			{

--- a/src/main/java/net/swedz/little_big_redstone/guide/LBRGuide.java
+++ b/src/main/java/net/swedz/little_big_redstone/guide/LBRGuide.java
@@ -74,7 +74,7 @@ public final class LBRGuide
 		return defaultColor;
 	}
 	
-	public static LogicType<?, ?> getLogicType(
+	public static LogicType getLogicType(
 			PageCompiler compiler,
 			LytErrorSink errorSink,
 			MdxJsxElementFields el,

--- a/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
+++ b/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
@@ -234,7 +234,7 @@ public final class MicrochipGuidebookScene extends LytBox implements ExportableR
 			int x,
 			int y,
 			DyeColor color,
-			LogicType<?, ?> type,
+			LogicType type,
 			CompoundTag data,
 			boolean hide,
 			PageCompiler compiler,

--- a/src/main/java/net/swedz/little_big_redstone/item/LogicItem.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/LogicItem.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 public final class LogicItem extends Item
 {
-	public LogicItem(Properties properties, LogicType<?, ?> type)
+	public LogicItem(Properties properties, LogicType type)
 	{
 		super(properties
 				.component(LBRComponents.LOGIC_CONFIG, type.defaultConfig())

--- a/src/main/java/net/swedz/little_big_redstone/item/stickynote/StickyNote.java
+++ b/src/main/java/net/swedz/little_big_redstone/item/stickynote/StickyNote.java
@@ -7,6 +7,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
@@ -120,10 +121,13 @@ public final class StickyNote
 		String matchedText;
 		if((matchedText = matcher.group("placeholder")) != null)
 		{
-			var placeholderKey = matcher.group("placeholderkey");
-			if(LogicTypes.exists(placeholderKey))
+			var placeholderKeyString = matcher.group("placeholderkey");
+			var placeholderKey = ResourceLocation.isValidPath(placeholderKeyString) ?
+					LBR.id(placeholderKeyString) :
+					ResourceLocation.parse(placeholderKeyString);
+			if(LogicTypes.REGISTRY.containsKey(placeholderKey))
 			{
-				var logicType = LogicTypes.get(placeholderKey);
+				var logicType = LogicTypes.REGISTRY.get(placeholderKey);
 				result.append(logicType.displaySymbol());
 			}
 			else

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
@@ -8,7 +8,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 import java.util.Arrays;
 import java.util.Optional;
 
-public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends LogicConfig<C>> implements LogicPortHolder
+public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends LogicConfig> implements LogicPortHolder
 {
 	protected C config;
 	
@@ -33,7 +33,7 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 	protected LogicComponent(Optional<DyeColor> color)
 	{
 		this.color = color;
-		this.config = this.type().defaultConfig();
+		this.config = (C) this.type().defaultConfig();
 	}
 	
 	public final C config()
@@ -72,7 +72,7 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 		color = Optional.empty();
 	}
 	
-	public abstract LogicType<L, C> type();
+	public abstract LogicType type();
 	
 	@Override
 	public final IntRange inputsAllowed()
@@ -157,7 +157,7 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 	
 	public final L copy()
 	{
-		var copy = this.type().defaultFactory().create();
+		var copy = (L) this.type().defaultFactory().create();
 		copy.loadFrom((L) this);
 		return copy;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
@@ -6,6 +6,7 @@ import com.mojang.serialization.Codec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.Microchip;
 import net.swedz.little_big_redstone.microchip.object.MicrochipObjectContainer;
 import net.swedz.little_big_redstone.microchip.wire.Wire;
@@ -33,7 +34,7 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 		for(var entry : components)
 		{
 			entry.component().updateConfigValidState(this);
-			if(entry.component().type() == LogicTypes.DEBUGGER)
+			if(entry.component().type().is(LBRLogicTypes.DEBUGGER))
 			{
 				debug = true;
 			}
@@ -96,7 +97,7 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 	
 	public LogicEntry addUnsafe(int x, int y, LogicComponent component, boolean visible)
 	{
-		if(component.type() == LogicTypes.DEBUGGER)
+		if(component.type().is(LBRLogicTypes.DEBUGGER))
 		{
 			if(debug)
 			{
@@ -116,7 +117,7 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 		var original = objects.remove(slot);
 		wiresRemoved.addAll(microchip.wires().removeAllOutputs(slot));
 		wiresRemoved.addAll(microchip.wires().removeAllInputs(slot));
-		if(original.component().type() == LogicTypes.DEBUGGER)
+		if(original.component().type().is(LBRLogicTypes.DEBUGGER))
 		{
 			debug = false;
 		}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicEntry.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicEntry.java
@@ -53,7 +53,7 @@ public record LogicEntry(
 		this(slot, x, y, component, true);
 	}
 	
-	public LogicType<?, ?> type()
+	public LogicType type()
 	{
 		return component.type();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTickingContext.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTickingContext.java
@@ -81,7 +81,7 @@ public final class LogicTickingContext implements LogicContextAccess
 		return Collections.unmodifiableList(dirtyEntries);
 	}
 	
-	public boolean checkValid(LogicConfig<?> config)
+	public boolean checkValid(LogicConfig config)
 	{
 		return config.checkValid(microchip.components());
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicType.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicType.java
@@ -20,23 +20,21 @@ import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import java.util.List;
 import java.util.Optional;
 
-public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>>(
+public record LogicType(
 		ResourceLocation id,
 		String englishName,
 		char symbol,
 		
-		MapCodec<L> codec,
-		StreamCodec<ByteBuf, L> streamCodec,
-		LogicFactory<L> defaultFactory,
+		MapCodec<? extends LogicComponent<?, ?>> codec,
+		StreamCodec<ByteBuf, ? extends LogicComponent<?, ?>> streamCodec,
+		LogicFactory<? extends LogicComponent<?, ?>> defaultFactory,
 		
-		MapCodec<C> configCodec,
-		StreamCodec<ByteBuf, C> configStreamCodec,
-		C defaultConfig
+		MapCodec<? extends LogicConfig> configCodec,
+		StreamCodec<ByteBuf, ? extends LogicConfig> configStreamCodec,
+		LogicConfig defaultConfig
 )
 {
-	public <L2 extends LogicComponent<L2, C2>, C2 extends LogicConfig<C2>> boolean is(
-			DeferredHolder<LogicType<?, ?>, LogicType<L2, C2>> other
-	)
+	public boolean is(DeferredHolder<LogicType, LogicType> other)
 	{
 		return id.equals(other.get().id());
 	}
@@ -51,7 +49,7 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 		return Component.literal(String.valueOf(symbol)).withStyle(Style.EMPTY.withFont(id.withPath("logic_component")));
 	}
 	
-	public Optional<List<Component>> tooltip(C config, boolean holdingShift, boolean includeConfig, boolean configHeader)
+	public Optional<List<Component>> tooltip(LogicConfig config, boolean holdingShift, boolean includeConfig, boolean configHeader)
 	{
 		List<Component> lines = Lists.newArrayList();
 		
@@ -92,7 +90,7 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 		return lines.isEmpty() ? Optional.empty() : Optional.of(lines);
 	}
 	
-	public Optional<List<Component>> tooltip(C config, boolean holdingShift, boolean includeConfig)
+	public Optional<List<Component>> tooltip(LogicConfig config, boolean holdingShift, boolean includeConfig)
 	{
 		return this.tooltip(config, holdingShift, includeConfig, true);
 	}
@@ -102,7 +100,7 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 		return BuiltInRegistries.ITEM.get(id);
 	}
 	
-	public ItemStack toStack(L component)
+	public ItemStack toStack(LogicComponent<?, ?> component)
 	{
 		var stack = new ItemStack(this.item());
 		stack.set(LBRComponents.LOGIC_CONFIG, component.config());
@@ -115,15 +113,15 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 		return this.toStack(defaultFactory.create());
 	}
 	
-	public L create(C config, Optional<DyeColor> color)
+	public LogicComponent<?, ?> create(LogicConfig config, Optional<DyeColor> color)
 	{
-		var logic = defaultFactory.create();
+		LogicComponent logic = defaultFactory.create();
 		logic.setConfig(config);
 		logic.setColor(color);
 		return logic;
 	}
 	
-	public L create(C config, DyeColor color)
+	public LogicComponent create(LogicConfig config, DyeColor color)
 	{
 		return this.create(config, Optional.ofNullable(color));
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicType.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicType.java
@@ -3,23 +3,25 @@ package net.swedz.little_big_redstone.microchip.object.logic;
 import com.google.common.collect.Lists;
 import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.registries.DeferredHolder;
 import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.LBRComponents;
-import net.swedz.little_big_redstone.LBRItems;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
 import java.util.List;
 import java.util.Optional;
 
 public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>>(
-		String id,
+		ResourceLocation id,
 		String englishName,
 		char symbol,
 		
@@ -32,14 +34,21 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 		C defaultConfig
 )
 {
+	public <L2 extends LogicComponent<L2, C2>, C2 extends LogicConfig<C2>> boolean is(
+			DeferredHolder<LogicType<?, ?>, LogicType<L2, C2>> other
+	)
+	{
+		return id.equals(other.get().id());
+	}
+	
 	public MutableComponent displayName()
 	{
-		return Component.translatable(LBR.id(id).toLanguageKey("item"));
+		return Component.translatable(id.toLanguageKey("item"));
 	}
 	
 	public MutableComponent displaySymbol()
 	{
-		return Component.literal(String.valueOf(symbol)).withStyle(Style.EMPTY.withFont(LBR.id("logic_component")));
+		return Component.literal(String.valueOf(symbol)).withStyle(Style.EMPTY.withFont(id.withPath("logic_component")));
 	}
 	
 	public Optional<List<Component>> tooltip(C config, boolean holdingShift, boolean includeConfig, boolean configHeader)
@@ -90,7 +99,7 @@ public record LogicType<L extends LogicComponent<L, C>, C extends LogicConfig<C>
 	
 	public Item item()
 	{
-		return LBRItems.valueOf(id).asItem();
+		return BuiltInRegistries.ITEM.get(id);
 	}
 	
 	public ItemStack toStack(L component)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
@@ -15,9 +15,9 @@ import net.swedz.tesseract.neoforge.helper.CodecHelper;
 
 public final class LogicTypes
 {
-	public static final ResourceKey<Registry<LogicType<?, ?>>> REGISTRY_KEY = ResourceKey.createRegistryKey(LBR.id("logic"));
+	public static final ResourceKey<Registry<LogicType>> REGISTRY_KEY = ResourceKey.createRegistryKey(LBR.id("logic"));
 	
-	public static final Registry<LogicType<?, ?>> REGISTRY = new RegistryBuilder<>(REGISTRY_KEY)
+	public static final Registry<LogicType> REGISTRY = new RegistryBuilder<>(REGISTRY_KEY)
 			.sync(true)
 			.create();
 	
@@ -48,7 +48,7 @@ public final class LogicTypes
 	 * @see Registry#byNameCodec()
 	 */
 	@Deprecated(since = "1.8.3-beta", forRemoval = true)
-	private static final Codec<LogicType<?, ?>> CODEC = RESOURCE_LOCATION_CODEC
+	private static final Codec<LogicType> CODEC = RESOURCE_LOCATION_CODEC
 			.comapFlatMap(
 					(id) -> REGISTRY
 							.getHolder(id)
@@ -62,7 +62,7 @@ public final class LogicTypes
 					(value) ->
 					{
 						var holder = REGISTRY.wrapAsHolder(value);
-						if(holder.getDelegate() instanceof Holder.Reference<LogicType<?, ?>> reference)
+						if(holder.getDelegate() instanceof Holder.Reference<LogicType> reference)
 						{
 							return DataResult.success(reference);
 						}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
@@ -1,166 +1,86 @@
 package net.swedz.little_big_redstone.microchip.object.logic;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
-import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
 import net.minecraft.network.codec.StreamCodec;
-import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculator;
-import net.swedz.little_big_redstone.microchip.object.logic.calculator.LogicCalculatorConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparator;
-import net.swedz.little_big_redstone.microchip.object.logic.comparator.LogicComparatorConfig;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.RegistryBuilder;
+import net.swedz.little_big_redstone.LBR;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.debug.LogicDebugger;
-import net.swedz.little_big_redstone.microchip.object.logic.debug.LogicDebuggerConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.ANDGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.LogicGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.NANDGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.NORGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.NOTGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.ORGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.XORGate;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ANDGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NANDGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NORGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NOTGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ORGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.gate.config.XORGateConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.io.LogicIO;
-import net.swedz.little_big_redstone.microchip.object.logic.io.LogicIOConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.latch.rs.RSNORLatch;
-import net.swedz.little_big_redstone.microchip.object.logic.latch.rs.RSNORLatchConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.latch.tflipflop.TFlipFlop;
-import net.swedz.little_big_redstone.microchip.object.logic.latch.tflipflop.TFlipFlopConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.pulse.PulseThrottler;
-import net.swedz.little_big_redstone.microchip.object.logic.pulse.PulseThrottlerConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRandomizer;
-import net.swedz.little_big_redstone.microchip.object.logic.randomizer.LogicRandomizerConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReader;
-import net.swedz.little_big_redstone.microchip.object.logic.reader.LogicReaderConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelector;
-import net.swedz.little_big_redstone.microchip.object.logic.selector.LogicSelectorConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.sequencer.LogicSequencer;
-import net.swedz.little_big_redstone.microchip.object.logic.sequencer.LogicSequencerConfig;
-import net.swedz.little_big_redstone.microchip.object.logic.tag.LogicTag;
-import net.swedz.little_big_redstone.microchip.object.logic.tag.LogicTagConfig;
-import org.apache.commons.lang3.mutable.MutableInt;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import net.swedz.tesseract.neoforge.helper.CodecHelper;
 
 public final class LogicTypes
 {
-	private static final List<LogicType<?, ?>>        TYPES     = Lists.newArrayList();
-	private static final Map<String, LogicType<?, ?>> TYPES_MAP = Maps.newHashMap();
+	public static final ResourceKey<Registry<LogicType<?, ?>>> REGISTRY_KEY = ResourceKey.createRegistryKey(LBR.id("logic"));
 	
-	private static final MutableInt SYMBOL = new MutableInt();
+	public static final Registry<LogicType<?, ?>> REGISTRY = new RegistryBuilder<>(REGISTRY_KEY)
+			.sync(true)
+			.create();
 	
-	static final Codec<LogicComponent> COMPONENT_CODEC = Codec.STRING
-			.comapFlatMap(LogicTypes::getMaybe, LogicType::id)
+	private static final Codec<ResourceLocation> RESOURCE_LOCATION_CODEC = Codec.STRING
+			.comapFlatMap(
+					(value) ->
+					{
+						if(ResourceLocation.isValidPath(value))
+						{
+							return DataResult.success(LBR.id(value));
+						}
+						return ResourceLocation.read(value);
+					},
+					ResourceLocation::toString
+			)
+			.stable();
+	
+	/**
+	 * <p>Prior to 1.8.3-beta, {@link LogicType} identifiers were a string path and the namespace was assumed to always
+	 * be LBR's. So, in order for old data to be able to be loaded on newer versions, this codec cannot simply be
+	 * {@link Registry#byNameCodec()}. That uses the vanilla {@link ResourceLocation#CODEC}, which would mean that the
+	 * Minecraft namespace would be used by default. This codec instead uses the
+	 * {@link LogicTypes#RESOURCE_LOCATION_CODEC}, which defaults to the LBR namespace instead of the Minecraft one.
+	 * Otherwise, this codec is merely a replication of what {@link Registry#byNameCodec()} would return.</p>
+	 *
+	 * <p>Will be removed in MC 26.1+.</p>
+	 *
+	 * @see Registry#byNameCodec()
+	 */
+	@Deprecated(since = "1.8.3-beta", forRemoval = true)
+	private static final Codec<LogicType<?, ?>> CODEC = RESOURCE_LOCATION_CODEC
+			.comapFlatMap(
+					(id) -> REGISTRY
+							.getHolder(id)
+							.map(DataResult::success)
+							.orElseGet(() -> DataResult
+									.error(() -> "Unknown registry key in " + REGISTRY.key() + ": " + id)),
+					(holder) -> holder.key().location()
+			)
+			.flatComapMap(
+					Holder.Reference::value,
+					(value) ->
+					{
+						var holder = REGISTRY.wrapAsHolder(value);
+						if(holder.getDelegate() instanceof Holder.Reference<LogicType<?, ?>> reference)
+						{
+							return DataResult.success(reference);
+						}
+						return DataResult.error(() -> "Unregistered holder in " + REGISTRY.key() + ": " + holder);
+					}
+			);
+	
+	static final Codec<LogicComponent> COMPONENT_CODEC = CODEC
 			.dispatch(LogicComponent::type, LogicType::codec);
 	
-	static final StreamCodec<ByteBuf, LogicComponent> COMPONENT_STREAM_CODEC = ByteBufCodecs.STRING_UTF8
-			.map(LogicTypes::get, LogicType::id)
+	static final StreamCodec<ByteBuf, LogicComponent> COMPONENT_STREAM_CODEC = CodecHelper
+			.forRegistryStream(REGISTRY)
 			.dispatch(LogicComponent::type, LogicType::streamCodec);
 	
-	static final Codec<LogicConfig> CONFIG_CODEC = Codec.STRING
-			.comapFlatMap(LogicTypes::getMaybe, LogicType::id)
+	static final Codec<LogicConfig> CONFIG_CODEC = CODEC
 			.dispatch(LogicConfig::type, LogicType::configCodec);
 	
-	static final StreamCodec<ByteBuf, LogicConfig> CONFIG_STREAM_CODEC = ByteBufCodecs.STRING_UTF8
-			.map(LogicTypes::get, LogicType::id)
+	static final StreamCodec<ByteBuf, LogicConfig> CONFIG_STREAM_CODEC = CodecHelper
+			.forRegistryStream(REGISTRY)
 			.dispatch(LogicConfig::type, LogicType::configStreamCodec);
-	
-	public static final LogicType<LogicDebugger, LogicDebuggerConfig> DEBUGGER = register("debugger", "Debugger", LogicDebugger.CODEC, LogicDebugger.STREAM_CODEC, LogicDebugger::new, LogicDebuggerConfig.CODEC, LogicDebuggerConfig.STREAM_CODEC, LogicDebuggerConfig.DEFAULT);
-	
-	public static final LogicType<LogicIO, LogicIOConfig>         IO     = register("io", "I/O Port", LogicIO.CODEC, LogicIO.STREAM_CODEC, LogicIO::new, LogicIOConfig.CODEC, LogicIOConfig.STREAM_CODEC, LogicIOConfig.DEFAULT);
-	public static final LogicType<LogicReader, LogicReaderConfig> READER = register("reader", "Reader", LogicReader.CODEC, LogicReader.STREAM_CODEC, LogicReader::new, LogicReaderConfig.CODEC, LogicReaderConfig.STREAM_CODEC, LogicReaderConfig.DEFAULT);
-	public static final LogicType<LogicTag, LogicTagConfig>       TAG    = register("tag", "Tag", LogicTag.CODEC, LogicTag.STREAM_CODEC, LogicTag::new, LogicTagConfig.CODEC, LogicTagConfig.STREAM_CODEC, LogicTagConfig.DEFAULT);
-	
-	public static final LogicType<NOTGate, NOTGateConfig>   NOT  = registerGate("not", "NOT", NOTGate.CODEC, NOTGate.STREAM_CODEC, NOTGate::new, NOTGateConfig.CODEC, NOTGateConfig.STREAM_CODEC, NOTGateConfig.DEFAULT);
-	public static final LogicType<ANDGate, ANDGateConfig>   AND  = registerGate("and", "AND", ANDGate.CODEC, ANDGate.STREAM_CODEC, ANDGate::new, ANDGateConfig.CODEC, ANDGateConfig.STREAM_CODEC, ANDGateConfig.DEFAULT);
-	public static final LogicType<NANDGate, NANDGateConfig> NAND = registerGate("nand", "NAND", NANDGate.CODEC, NANDGate.STREAM_CODEC, NANDGate::new, NANDGateConfig.CODEC, NANDGateConfig.STREAM_CODEC, NANDGateConfig.DEFAULT);
-	public static final LogicType<ORGate, ORGateConfig>     OR   = registerGate("or", "OR", ORGate.CODEC, ORGate.STREAM_CODEC, ORGate::new, ORGateConfig.CODEC, ORGateConfig.STREAM_CODEC, ORGateConfig.DEFAULT);
-	public static final LogicType<NORGate, NORGateConfig>   NOR  = registerGate("nor", "NOR", NORGate.CODEC, NORGate.STREAM_CODEC, NORGate::new, NORGateConfig.CODEC, NORGateConfig.STREAM_CODEC, NORGateConfig.DEFAULT);
-	public static final LogicType<XORGate, XORGateConfig>   XOR  = registerGate("xor", "XOR", XORGate.CODEC, XORGate.STREAM_CODEC, XORGate::new, XORGateConfig.CODEC, XORGateConfig.STREAM_CODEC, XORGateConfig.DEFAULT);
-	
-	public static final LogicType<LogicSequencer, LogicSequencerConfig>   SEQUENCER       = register("sequencer", "Sequencer", LogicSequencer.CODEC, LogicSequencer.STREAM_CODEC, LogicSequencer::new, LogicSequencerConfig.CODEC, LogicSequencerConfig.STREAM_CODEC, LogicSequencerConfig.DEFAULT);
-	public static final LogicType<PulseThrottler, PulseThrottlerConfig>   PULSE_THROTTLER = register("pulse_throttler", "Pulse Throttler", PulseThrottler.CODEC, PulseThrottler.STREAM_CODEC, PulseThrottler::new, PulseThrottlerConfig.CODEC, PulseThrottlerConfig.STREAM_CODEC, PulseThrottlerConfig.DEFAULT);
-	public static final LogicType<LogicSelector, LogicSelectorConfig>     SELECTOR        = register("selector", "Selector", LogicSelector.CODEC, LogicSelector.STREAM_CODEC, LogicSelector::new, LogicSelectorConfig.CODEC, LogicSelectorConfig.STREAM_CODEC, LogicSelectorConfig.DEFAULT);
-	public static final LogicType<LogicRandomizer, LogicRandomizerConfig> RANDOMIZER      = register("randomizer", "Randomizer", LogicRandomizer.CODEC, LogicRandomizer.STREAM_CODEC, LogicRandomizer::new, LogicRandomizerConfig.CODEC, LogicRandomizerConfig.STREAM_CODEC, LogicRandomizerConfig.DEFAULT);
-	public static final LogicType<LogicComparator, LogicComparatorConfig> COMPARATOR      = register("comparator", "Comparator", LogicComparator.CODEC, LogicComparator.STREAM_CODEC, LogicComparator::new, LogicComparatorConfig.CODEC, LogicComparatorConfig.STREAM_CODEC, LogicComparatorConfig.DEFAULT);
-	public static final LogicType<LogicCalculator, LogicCalculatorConfig> CALCULATOR      = register("calculator", "Calculator", LogicCalculator.CODEC, LogicCalculator.STREAM_CODEC, LogicCalculator::new, LogicCalculatorConfig.CODEC, LogicCalculatorConfig.STREAM_CODEC, LogicCalculatorConfig.DEFAULT);
-	
-	public static final LogicType<TFlipFlop, TFlipFlopConfig>   T_FLIP_FLOP  = register("t_flip_flop", "T Flip-Flop", TFlipFlop.CODEC, TFlipFlop.STREAM_CODEC, TFlipFlop::new, TFlipFlopConfig.CODEC, TFlipFlopConfig.STREAM_CODEC, TFlipFlopConfig.DEFAULT);
-	public static final LogicType<RSNORLatch, RSNORLatchConfig> RS_NOR_LATCH = register("rs_nor_latch", "RS NOR Latch", RSNORLatch.CODEC, RSNORLatch.STREAM_CODEC, RSNORLatch::new, RSNORLatchConfig.CODEC, RSNORLatchConfig.STREAM_CODEC, RSNORLatchConfig.DEFAULT);
-	
-	public static List<LogicType<?, ?>> values()
-	{
-		return Collections.unmodifiableList(TYPES);
-	}
-	
-	public static boolean exists(String id)
-	{
-		return TYPES_MAP.containsKey(id);
-	}
-	
-	private static DataResult<LogicType<?, ?>> getMaybe(String id)
-	{
-		var type = TYPES_MAP.get(id);
-		return type == null ? DataResult.error(() -> "No logic type exists for the id %s".formatted(id)) : DataResult.success(type);
-	}
-	
-	public static LogicType<?, ?> get(String id)
-	{
-		return getMaybe(id).getOrThrow(IllegalArgumentException::new);
-	}
-	
-	private static <T extends LogicComponent<T, C>, C extends LogicConfig<C>> LogicType<T, C> register(
-			String id,
-			String englishName,
-			MapCodec<T> codec,
-			StreamCodec<ByteBuf, T> streamCodec,
-			LogicFactory<T> defaultFactory,
-			MapCodec<C> configCodec,
-			StreamCodec<ByteBuf, C> configStreamCodec,
-			C defaultConfig
-	)
-	{
-		var type = new LogicType<>(
-				id,
-				englishName,
-				(char) (SYMBOL.getAndIncrement() + (int) '0'),
-				codec,
-				streamCodec,
-				defaultFactory,
-				configCodec,
-				configStreamCodec,
-				defaultConfig
-		);
-		TYPES.add(type);
-		TYPES_MAP.put(id, type);
-		return type;
-	}
-	
-	private static <T extends LogicGate<T, C>, C extends LogicConfig<C>> LogicType<T, C> registerGate(
-			String id,
-			String englishName,
-			MapCodec<T> codec,
-			StreamCodec<ByteBuf, T> streamCodec,
-			LogicFactory<T> defaultFactory,
-			MapCodec<C> configCodec,
-			StreamCodec<ByteBuf, C> configStreamCodec,
-			C defaultConfig
-	)
-	{
-		return register(id + "_gate", englishName + " Gate", codec, streamCodec, defaultFactory, configCodec, configStreamCodec, defaultConfig);
-	}
-	
-	public static void init()
-	{
-	}
 }

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTypes.java
@@ -36,18 +36,15 @@ public final class LogicTypes
 			.stable();
 	
 	/**
-	 * <p>Prior to 1.8.3-beta, {@link LogicType} identifiers were a string path and the namespace was assumed to always
-	 * be LBR's. So, in order for old data to be able to be loaded on newer versions, this codec cannot simply be
+	 * <p>In the past, {@link LogicType} identifiers were a string path and the namespace was assumed to always be
+	 * LBR's. So, in order for old data to be able to be loaded on newer versions, this codec cannot simply be
 	 * {@link Registry#byNameCodec()}. That uses the vanilla {@link ResourceLocation#CODEC}, which would mean that the
 	 * Minecraft namespace would be used by default. This codec instead uses the
 	 * {@link LogicTypes#RESOURCE_LOCATION_CODEC}, which defaults to the LBR namespace instead of the Minecraft one.
 	 * Otherwise, this codec is merely a replication of what {@link Registry#byNameCodec()} would return.</p>
 	 *
-	 * <p>Will be removed in MC 26.1+.</p>
-	 *
 	 * @see Registry#byNameCodec()
 	 */
-	@Deprecated(since = "1.8.3-beta", forRemoval = true)
 	private static final Codec<LogicType> CODEC = RESOURCE_LOCATION_CODEC
 			.comapFlatMap(
 					(id) -> REGISTRY

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
@@ -8,10 +8,10 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -55,7 +55,7 @@ public final class LogicCalculator extends LogicComponent<LogicCalculator, Logic
 	@Override
 	public LogicType<LogicCalculator, LogicCalculatorConfig> type()
 	{
-		return LogicTypes.CALCULATOR;
+		return LBRLogicTypes.CALCULATOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
@@ -53,7 +53,7 @@ public final class LogicCalculator extends LogicComponent<LogicCalculator, Logic
 	}
 	
 	@Override
-	public LogicType<LogicCalculator, LogicCalculatorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.CALCULATOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -43,7 +43,7 @@ public record LogicCalculatorConfig(
 	@Override
 	public LogicType<?, LogicCalculatorConfig> type()
 	{
-		return LogicTypes.CALCULATOR;
+		return LBRLogicTypes.CALCULATOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
@@ -20,7 +20,7 @@ import java.util.List;
 public record LogicCalculatorConfig(
 		LogicCalculatorMode mode,
 		int inputs
-) implements LogicConfig<LogicCalculatorConfig>
+) implements LogicConfig
 {
 	public static final LogicCalculatorConfig DEFAULT = new LogicCalculatorConfig(
 			LogicCalculatorMode.ADDITION,
@@ -41,7 +41,7 @@ public record LogicCalculatorConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicCalculatorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.CALCULATOR.get();
 	}
@@ -92,7 +92,7 @@ public record LogicCalculatorConfig(
 	}
 	
 	@Override
-	public LogicConfigMenuProvider<LogicCalculatorConfig> getMenuProvider()
+	public LogicConfigMenuProvider<?> getMenuProvider()
 	{
 		return new LogicCalculatorConfigMenuProvider(this);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
@@ -7,10 +7,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicAccumulationMode;
 
 import java.util.Objects;
@@ -55,7 +55,7 @@ public final class LogicComparator extends LogicComponent<LogicComparator, Logic
 	@Override
 	public LogicType<LogicComparator, LogicComparatorConfig> type()
 	{
-		return LogicTypes.COMPARATOR;
+		return LBRLogicTypes.COMPARATOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
@@ -53,7 +53,7 @@ public final class LogicComparator extends LogicComponent<LogicComparator, Logic
 	}
 	
 	@Override
-	public LogicType<LogicComparator, LogicComparatorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.COMPARATOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicAccumulationMode;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicComparisonMode;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
@@ -53,7 +53,7 @@ public record LogicComparatorConfig(
 	@Override
 	public LogicType<?, LogicComparatorConfig> type()
 	{
-		return LogicTypes.COMPARATOR;
+		return LBRLogicTypes.COMPARATOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
@@ -24,7 +24,7 @@ public record LogicComparatorConfig(
 		int signalStrength,
 		LogicComparisonMode signalComparison,
 		int inputs
-) implements LogicConfig<LogicComparatorConfig>
+) implements LogicConfig
 {
 	public static final LogicComparatorConfig DEFAULT = new LogicComparatorConfig(
 			LogicAccumulationMode.ALL,
@@ -51,7 +51,7 @@ public record LogicComparatorConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicComparatorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.COMPARATOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/LogicConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/LogicConfig.java
@@ -8,9 +8,9 @@ import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicCon
 
 import java.util.List;
 
-public interface LogicConfig<C extends LogicConfig<C>> extends LogicPortHolder
+public interface LogicConfig extends LogicPortHolder
 {
-	LogicType<?, C> type();
+	LogicType type();
 	
 	default boolean checkValid(LogicComponents components)
 	{
@@ -34,7 +34,7 @@ public interface LogicConfig<C extends LogicConfig<C>> extends LogicPortHolder
 		return false;
 	}
 	
-	default LogicConfigMenuProvider<C> getMenuProvider()
+	default LogicConfigMenuProvider<?> getMenuProvider()
 	{
 		throw new UnsupportedOperationException("LogicConfig#getMenuProvider must be implemented when LogicConfig#hasMenu returns true");
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/menu/LogicConfigMenuProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/config/menu/LogicConfigMenuProvider.java
@@ -2,7 +2,7 @@ package net.swedz.little_big_redstone.microchip.object.logic.config.menu;
 
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
-public abstract class LogicConfigMenuProvider<C extends LogicConfig<C>>
+public abstract class LogicConfigMenuProvider<C extends LogicConfig>
 {
 	protected C config;
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
@@ -38,7 +38,7 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	}
 	
 	@Override
-	public LogicType<LogicDebugger, LogicDebuggerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.DEBUGGER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
@@ -6,10 +6,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -40,7 +40,7 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	@Override
 	public LogicType<LogicDebugger, LogicDebuggerConfig> type()
 	{
-		return LogicTypes.DEBUGGER;
+		return LBRLogicTypes.DEBUGGER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
@@ -8,7 +8,7 @@ import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
 
-public record LogicDebuggerConfig() implements LogicConfig<LogicDebuggerConfig>
+public record LogicDebuggerConfig() implements LogicConfig
 {
 	public static final LogicDebuggerConfig DEFAULT = new LogicDebuggerConfig();
 	
@@ -17,7 +17,7 @@ public record LogicDebuggerConfig() implements LogicConfig<LogicDebuggerConfig>
 	public static final StreamCodec<ByteBuf, LogicDebuggerConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override
-	public LogicType<?, LogicDebuggerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.DEBUGGER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
@@ -3,8 +3,8 @@ package net.swedz.little_big_redstone.microchip.object.logic.debug;
 import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
 
@@ -19,7 +19,7 @@ public record LogicDebuggerConfig() implements LogicConfig<LogicDebuggerConfig>
 	@Override
 	public LogicType<?, LogicDebuggerConfig> type()
 	{
-		return LogicTypes.DEBUGGER;
+		return LBRLogicTypes.DEBUGGER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ANDGateConfig;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public final class ANDGate extends LogicGate<ANDGate, ANDGateConfig>
 	@Override
 	public LogicType<ANDGate, ANDGateConfig> type()
 	{
-		return LogicTypes.AND;
+		return LBRLogicTypes.AND.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
@@ -34,7 +34,7 @@ public final class ANDGate extends LogicGate<ANDGate, ANDGateConfig>
 	}
 	
 	@Override
-	public LogicType<ANDGate, ANDGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.AND.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
@@ -15,9 +15,9 @@ import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig<C>> extends LogicComponent<G, C>
+public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig> extends LogicComponent<G, C>
 {
-	protected static <G extends LogicGate<G, C>, C extends LogicConfig<C>> MapCodec<G> mapCodec(MapCodec<C> configCodec, Function3<C, Optional<DyeColor>, Integer, G> function)
+	protected static <G extends LogicGate<G, C>, C extends LogicConfig> MapCodec<G> mapCodec(MapCodec<C> configCodec, Function3<C, Optional<DyeColor>, Integer, G> function)
 	{
 		return RecordCodecBuilder.mapCodec((instance) -> instance
 				.group(
@@ -28,7 +28,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 				.apply(instance, function));
 	}
 	
-	protected static <G extends LogicGate<G, C>, C extends LogicConfig<C>> MapCodec<G> mapCodec(BiFunction<Optional<DyeColor>, Integer, G> creator)
+	protected static <G extends LogicGate<G, C>, C extends LogicConfig> MapCodec<G> mapCodec(BiFunction<Optional<DyeColor>, Integer, G> creator)
 	{
 		return RecordCodecBuilder.mapCodec((instance) -> instance
 				.group(
@@ -38,7 +38,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 				.apply(instance, creator));
 	}
 	
-	protected static <G extends LogicGate<G, C>, C extends LogicConfig<C>> StreamCodec<ByteBuf, G> streamCodec(StreamCodec<ByteBuf, C> configCodec, Function3<C, Optional<DyeColor>, Integer, G> function)
+	protected static <G extends LogicGate<G, C>, C extends LogicConfig> StreamCodec<ByteBuf, G> streamCodec(StreamCodec<ByteBuf, C> configCodec, Function3<C, Optional<DyeColor>, Integer, G> function)
 	{
 		return StreamCodec.composite(
 				configCodec, LogicComponent::config,
@@ -48,7 +48,7 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 		);
 	}
 	
-	protected static <G extends LogicGate<G, C>, C extends LogicConfig<C>> StreamCodec<ByteBuf, G> streamCodec(BiFunction<Optional<DyeColor>, Integer, G> creator)
+	protected static <G extends LogicGate<G, C>, C extends LogicConfig> StreamCodec<ByteBuf, G> streamCodec(BiFunction<Optional<DyeColor>, Integer, G> creator)
 	{
 		return StreamCodec.composite(
 				ByteBufCodecs.optional(DyeColor.STREAM_CODEC), LogicGate::color,

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
@@ -34,7 +34,7 @@ public final class NANDGate extends LogicGate<NANDGate, NANDGateConfig>
 	}
 	
 	@Override
-	public LogicType<NANDGate, NANDGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NAND.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NANDGateConfig;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public final class NANDGate extends LogicGate<NANDGate, NANDGateConfig>
 	@Override
 	public LogicType<NANDGate, NANDGateConfig> type()
 	{
-		return LogicTypes.NAND;
+		return LBRLogicTypes.NAND.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
@@ -34,7 +34,7 @@ public final class NORGate extends LogicGate<NORGate, NORGateConfig>
 	}
 	
 	@Override
-	public LogicType<NORGate, NORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NORGateConfig;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public final class NORGate extends LogicGate<NORGate, NORGateConfig>
 	@Override
 	public LogicType<NORGate, NORGateConfig> type()
 	{
-		return LogicTypes.NOR;
+		return LBRLogicTypes.NOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
@@ -29,7 +29,7 @@ public final class NOTGate extends LogicGate<NOTGate, NOTGateConfig>
 	}
 	
 	@Override
-	public LogicType<NOTGate, NOTGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NOT.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NOTGateConfig;
 
 import java.util.Objects;
@@ -31,7 +31,7 @@ public final class NOTGate extends LogicGate<NOTGate, NOTGateConfig>
 	@Override
 	public LogicType<NOTGate, NOTGateConfig> type()
 	{
-		return LogicTypes.NOT;
+		return LBRLogicTypes.NOT.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ORGateConfig;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public final class ORGate extends LogicGate<ORGate, ORGateConfig>
 	@Override
 	public LogicType<ORGate, ORGateConfig> type()
 	{
-		return LogicTypes.OR;
+		return LBRLogicTypes.OR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
@@ -34,7 +34,7 @@ public final class ORGate extends LogicGate<ORGate, ORGateConfig>
 	}
 	
 	@Override
-	public LogicType<ORGate, ORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.OR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
@@ -4,9 +4,9 @@ import com.mojang.serialization.MapCodec;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.XORGateConfig;
 
 import java.util.Objects;
@@ -36,7 +36,7 @@ public final class XORGate extends LogicGate<XORGate, XORGateConfig>
 	@Override
 	public LogicType<XORGate, XORGateConfig> type()
 	{
-		return LogicTypes.XOR;
+		return LBRLogicTypes.XOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
@@ -34,7 +34,7 @@ public final class XORGate extends LogicGate<XORGate, XORGateConfig>
 	}
 	
 	@Override
-	public LogicType<XORGate, XORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.XOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
@@ -28,7 +28,7 @@ public final class ANDGateConfig extends MultiLogicGateConfig<ANDGateConfig>
 	}
 	
 	@Override
-	public LogicType<?, ANDGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.AND.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public final class ANDGateConfig extends MultiLogicGateConfig<ANDGateConfig>
 	@Override
 	public LogicType<?, ANDGateConfig> type()
 	{
-		return LogicTypes.AND;
+		return LBRLogicTypes.AND.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-public abstract class MultiLogicGateConfig<C extends MultiLogicGateConfig<C>> implements LogicConfig<C>
+public abstract class MultiLogicGateConfig<C extends MultiLogicGateConfig<C>> implements LogicConfig
 {
 	public static <C extends MultiLogicGateConfig<C>> MapCodec<C> codec(Function<Integer, C> creator)
 	{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public final class NANDGateConfig extends MultiLogicGateConfig<NANDGateConfig>
 	@Override
 	public LogicType<?, NANDGateConfig> type()
 	{
-		return LogicTypes.NAND;
+		return LBRLogicTypes.NAND.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
@@ -28,7 +28,7 @@ public final class NANDGateConfig extends MultiLogicGateConfig<NANDGateConfig>
 	}
 	
 	@Override
-	public LogicType<?, NANDGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NAND.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public final class NORGateConfig extends MultiLogicGateConfig<NORGateConfig>
 	@Override
 	public LogicType<?, NORGateConfig> type()
 	{
-		return LogicTypes.NOR;
+		return LBRLogicTypes.NOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
@@ -28,7 +28,7 @@ public final class NORGateConfig extends MultiLogicGateConfig<NORGateConfig>
 	}
 	
 	@Override
-	public LogicType<?, NORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
@@ -17,7 +17,7 @@ public record NOTGateConfig() implements SingleLogicGateConfig<NOTGateConfig>
 	public static final StreamCodec<ByteBuf, NOTGateConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override
-	public LogicType<?, NOTGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.NOT.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public record NOTGateConfig() implements SingleLogicGateConfig<NOTGateConfig>
 	@Override
 	public LogicType<?, NOTGateConfig> type()
 	{
-		return LogicTypes.NOT;
+		return LBRLogicTypes.NOT.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public final class ORGateConfig extends MultiLogicGateConfig<ORGateConfig>
 	@Override
 	public LogicType<?, ORGateConfig> type()
 	{
-		return LogicTypes.OR;
+		return LBRLogicTypes.OR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
@@ -28,7 +28,7 @@ public final class ORGateConfig extends MultiLogicGateConfig<ORGateConfig>
 	}
 	
 	@Override
-	public LogicType<?, ORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.OR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
@@ -3,7 +3,7 @@ package net.swedz.little_big_redstone.microchip.object.logic.gate.config;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
 
-public interface SingleLogicGateConfig<C extends SingleLogicGateConfig<C>> extends LogicConfig<C>
+public interface SingleLogicGateConfig<C extends SingleLogicGateConfig<C>> extends LogicConfig
 {
 	@Override
 	default IntRange inputsAllowed()

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
@@ -28,7 +28,7 @@ public final class XORGateConfig extends MultiLogicGateConfig<XORGateConfig>
 	}
 	
 	@Override
-	public LogicType<?, XORGateConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.XOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public final class XORGateConfig extends MultiLogicGateConfig<XORGateConfig>
 	@Override
 	public LogicType<?, XORGateConfig> type()
 	{
-		return LogicTypes.XOR;
+		return LBRLogicTypes.XOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
@@ -89,7 +89,7 @@ public final class LogicIO extends LogicComponent<LogicIO, LogicIOConfig> implem
 	}
 	
 	@Override
-	public LogicType<LogicIO, LogicIOConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.IO.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
@@ -7,13 +7,13 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -91,7 +91,7 @@ public final class LogicIO extends LogicComponent<LogicIO, LogicIOConfig> implem
 	@Override
 	public LogicType<LogicIO, LogicIOConfig> type()
 	{
-		return LogicTypes.IO;
+		return LBRLogicTypes.IO.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
@@ -9,10 +9,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponents;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicMode;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicComparisonMode;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
@@ -59,7 +59,7 @@ public record LogicIOConfig(
 	@Override
 	public LogicType<?, LogicIOConfig> type()
 	{
-		return LogicTypes.IO;
+		return LBRLogicTypes.IO.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
@@ -27,7 +27,7 @@ public record LogicIOConfig(
 		int signalStrength,
 		LogicComparisonMode signalComparison,
 		LogicPowerOutputType powerType
-) implements LogicConfig<LogicIOConfig>
+) implements LogicConfig
 {
 	public static final MapCodec<LogicIOConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
@@ -57,7 +57,7 @@ public record LogicIOConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicIOConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.IO.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
@@ -7,10 +7,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -46,7 +46,7 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	@Override
 	public LogicType<RSNORLatch, RSNORLatchConfig> type()
 	{
-		return LogicTypes.RS_NOR_LATCH;
+		return LBRLogicTypes.RS_NOR_LATCH.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
@@ -44,7 +44,7 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	}
 	
 	@Override
-	public LogicType<RSNORLatch, RSNORLatchConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.RS_NOR_LATCH.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
@@ -12,7 +12,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 import java.util.List;
 
-public record RSNORLatchConfig() implements LogicConfig<RSNORLatchConfig>
+public record RSNORLatchConfig() implements LogicConfig
 {
 	public static final RSNORLatchConfig DEFAULT = new RSNORLatchConfig();
 	
@@ -21,7 +21,7 @@ public record RSNORLatchConfig() implements LogicConfig<RSNORLatchConfig>
 	public static final StreamCodec<ByteBuf, RSNORLatchConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override
-	public LogicType<?, RSNORLatchConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.RS_NOR_LATCH.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
 
@@ -23,7 +23,7 @@ public record RSNORLatchConfig() implements LogicConfig<RSNORLatchConfig>
 	@Override
 	public LogicType<?, RSNORLatchConfig> type()
 	{
-		return LogicTypes.RS_NOR_LATCH;
+		return LBRLogicTypes.RS_NOR_LATCH.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
@@ -48,7 +48,7 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	}
 	
 	@Override
-	public LogicType<TFlipFlop, TFlipFlopConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.T_FLIP_FLOP.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
@@ -7,10 +7,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -50,7 +50,7 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	@Override
 	public LogicType<TFlipFlop, TFlipFlopConfig> type()
 	{
-		return LogicTypes.T_FLIP_FLOP;
+		return LBRLogicTypes.T_FLIP_FLOP.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
@@ -12,7 +12,7 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 import java.util.List;
 
-public record TFlipFlopConfig() implements LogicConfig<TFlipFlopConfig>
+public record TFlipFlopConfig() implements LogicConfig
 {
 	public static final TFlipFlopConfig DEFAULT = new TFlipFlopConfig();
 	
@@ -21,7 +21,7 @@ public record TFlipFlopConfig() implements LogicConfig<TFlipFlopConfig>
 	public static final StreamCodec<ByteBuf, TFlipFlopConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override
-	public LogicType<?, TFlipFlopConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.T_FLIP_FLOP.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
@@ -5,8 +5,8 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
 
@@ -23,7 +23,7 @@ public record TFlipFlopConfig() implements LogicConfig<TFlipFlopConfig>
 	@Override
 	public LogicType<?, TFlipFlopConfig> type()
 	{
-		return LogicTypes.T_FLIP_FLOP;
+		return LBRLogicTypes.T_FLIP_FLOP.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
@@ -68,7 +68,7 @@ public final class PulseThrottler extends LogicComponent<PulseThrottler, PulseTh
 	}
 	
 	@Override
-	public LogicType<PulseThrottler, PulseThrottlerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.PULSE_THROTTLER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
@@ -8,10 +8,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Optional;
 
@@ -70,7 +70,7 @@ public final class PulseThrottler extends LogicComponent<PulseThrottler, PulseTh
 	@Override
 	public LogicType<PulseThrottler, PulseThrottlerConfig> type()
 	{
-		return LogicTypes.PULSE_THROTTLER;
+		return LBRLogicTypes.PULSE_THROTTLER.get();
 	}
 	
 	public boolean lastInput()

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
 public record PulseThrottlerConfig(
 		long outputDuration,
 		int signalStrength
-) implements LogicConfig<PulseThrottlerConfig>
+) implements LogicConfig
 {
 	public static final PulseThrottlerConfig DEFAULT = new PulseThrottlerConfig(
 			1,
@@ -40,7 +40,7 @@ public record PulseThrottlerConfig(
 	);
 	
 	@Override
-	public LogicType<?, PulseThrottlerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.PULSE_THROTTLER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -42,7 +42,7 @@ public record PulseThrottlerConfig(
 	@Override
 	public LogicType<?, PulseThrottlerConfig> type()
 	{
-		return LogicTypes.PULSE_THROTTLER;
+		return LBRLogicTypes.PULSE_THROTTLER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
@@ -105,7 +105,7 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	}
 	
 	@Override
-	public LogicType<LogicRandomizer, LogicRandomizerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.RANDOMIZER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
@@ -9,10 +9,10 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Optional;
 
@@ -107,7 +107,7 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	@Override
 	public LogicType<LogicRandomizer, LogicRandomizerConfig> type()
 	{
-		return LogicTypes.RANDOMIZER;
+		return LBRLogicTypes.RANDOMIZER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
 public record LogicRandomizerConfig(
 		int outputs,
 		float chance
-) implements LogicConfig<LogicRandomizerConfig>
+) implements LogicConfig
 {
 	public static final LogicRandomizerConfig DEFAULT = new LogicRandomizerConfig(
 			1,
@@ -40,7 +40,7 @@ public record LogicRandomizerConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicRandomizerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.RANDOMIZER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -42,7 +42,7 @@ public record LogicRandomizerConfig(
 	@Override
 	public LogicType<?, LogicRandomizerConfig> type()
 	{
-		return LogicTypes.RANDOMIZER;
+		return LBRLogicTypes.RANDOMIZER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
@@ -162,7 +162,7 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 	}
 	
 	@Override
-	public LogicType<LogicReader, LogicReaderConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.READER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
@@ -9,13 +9,13 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -164,7 +164,7 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 	@Override
 	public LogicType<LogicReader, LogicReaderConfig> type()
 	{
-		return LogicTypes.READER;
+		return LBRLogicTypes.READER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
@@ -25,7 +25,7 @@ public record LogicReaderConfig(
 		LogicReaderThreshold fillThreshold,
 		int signalThreshold,
 		LogicComparisonMode comparison
-) implements LogicConfig<LogicReaderConfig>
+) implements LogicConfig
 {
 	public static final LogicReaderConfig DEFAULT = new LogicReaderConfig(
 			LogicReaderMode.ITEM,
@@ -55,7 +55,7 @@ public record LogicReaderConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicReaderConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.READER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
@@ -9,8 +9,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicComparisonMode;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
@@ -57,7 +57,7 @@ public record LogicReaderConfig(
 	@Override
 	public LogicType<?, LogicReaderConfig> type()
 	{
-		return LogicTypes.READER;
+		return LBRLogicTypes.READER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/register/DeferredLogicType.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/register/DeferredLogicType.java
@@ -1,0 +1,13 @@
+package net.swedz.little_big_redstone.microchip.object.logic.register;
+
+import net.minecraft.resources.ResourceKey;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
+
+public final class DeferredLogicType<I extends LogicType> extends DeferredHolder<LogicType, I>
+{
+	DeferredLogicType(ResourceKey<LogicType> key)
+	{
+		super(key);
+	}
+}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/register/LogicTypeDeferredRegister.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/register/LogicTypeDeferredRegister.java
@@ -1,0 +1,37 @@
+package net.swedz.little_big_redstone.microchip.object.logic.register;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class LogicTypeDeferredRegister extends DeferredRegister<LogicType>
+{
+	public LogicTypeDeferredRegister(String namespace)
+	{
+		super(LogicTypes.REGISTRY_KEY, namespace);
+	}
+	
+	@Override
+	public <I extends LogicType> DeferredLogicType<I> register(String name, Supplier<? extends I> sup)
+	{
+		return (DeferredLogicType<I>) super.register(name, sup);
+	}
+	
+	@Override
+	public <I extends LogicType> DeferredLogicType<I> register(String name, Function<ResourceLocation, ? extends I> func)
+	{
+		return (DeferredLogicType<I>) super.register(name, func);
+	}
+	
+	@Override
+	protected <I extends LogicType> DeferredLogicType<I> createHolder(ResourceKey<? extends Registry<LogicType>> registryKey, ResourceLocation key)
+	{
+		return new DeferredLogicType(ResourceKey.create(registryKey, key));
+	}
+}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
@@ -8,10 +8,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Optional;
 
@@ -135,7 +135,7 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 	@Override
 	public LogicType<LogicSelector, LogicSelectorConfig> type()
 	{
-		return LogicTypes.SELECTOR;
+		return LBRLogicTypes.SELECTOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
@@ -133,7 +133,7 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 	}
 	
 	@Override
-	public LogicType<LogicSelector, LogicSelectorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.SELECTOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
@@ -21,7 +21,7 @@ public record LogicSelectorConfig(
 		LogicSelectorMode mode,
 		int outputs,
 		boolean passSignal
-) implements LogicConfig<LogicSelectorConfig>
+) implements LogicConfig
 {
 	public static final LogicSelectorConfig DEFAULT = new LogicSelectorConfig(
 			LogicSelectorMode.COUNTER,
@@ -45,7 +45,7 @@ public record LogicSelectorConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicSelectorConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.SELECTOR.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -47,7 +47,7 @@ public record LogicSelectorConfig(
 	@Override
 	public LogicType<?, LogicSelectorConfig> type()
 	{
-		return LogicTypes.SELECTOR;
+		return LBRLogicTypes.SELECTOR.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
@@ -8,10 +8,10 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 
 import java.util.Optional;
 
@@ -121,7 +121,7 @@ public final class LogicSequencer extends LogicComponent<LogicSequencer, LogicSe
 	@Override
 	public LogicType<LogicSequencer, LogicSequencerConfig> type()
 	{
-		return LogicTypes.SEQUENCER;
+		return LBRLogicTypes.SEQUENCER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
@@ -119,7 +119,7 @@ public final class LogicSequencer extends LogicComponent<LogicSequencer, LogicSe
 	}
 	
 	@Override
-	public LogicType<LogicSequencer, LogicSequencerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.SEQUENCER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
@@ -23,7 +23,7 @@ public record LogicSequencerConfig(
 		long outputDelay,
 		boolean autoReset,
 		boolean resetPort
-) implements LogicConfig<LogicSequencerConfig>
+) implements LogicConfig
 {
 	public static final LogicSequencerConfig DEFAULT = new LogicSequencerConfig(
 			LogicSequencerMode.WEAK,
@@ -50,7 +50,7 @@ public record LogicSequencerConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicSequencerConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.SEQUENCER.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
@@ -8,9 +8,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicGridSize;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -52,7 +52,7 @@ public record LogicSequencerConfig(
 	@Override
 	public LogicType<?, LogicSequencerConfig> type()
 	{
-		return LogicTypes.SEQUENCER;
+		return LBRLogicTypes.SEQUENCER.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
@@ -7,13 +7,13 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.tag.MicrochipTagSystem;
 import net.swedz.little_big_redstone.microchip.tag.TagOwnerKey;
 
@@ -59,7 +59,7 @@ public final class LogicTag extends LogicComponent<LogicTag, LogicTagConfig> imp
 	@Override
 	public LogicType<LogicTag, LogicTagConfig> type()
 	{
-		return LogicTypes.TAG;
+		return LBRLogicTypes.TAG.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
@@ -57,7 +57,7 @@ public final class LogicTag extends LogicComponent<LogicTag, LogicTagConfig> imp
 	}
 	
 	@Override
-	public LogicType<LogicTag, LogicTagConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.TAG.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.swedz.little_big_redstone.LBR;
+import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 import net.swedz.little_big_redstone.microchip.object.logic.config.menu.LogicConfigMenuProvider;
 import net.swedz.tesseract.neoforge.api.range.IntRange;
@@ -50,7 +50,7 @@ public record LogicTagConfig(
 	@Override
 	public LogicType<?, LogicTagConfig> type()
 	{
-		return LogicTypes.TAG;
+		return LBRLogicTypes.TAG.get();
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
@@ -21,7 +21,7 @@ public record LogicTagConfig(
 		LogicTagLabel label,
 		int threshold,
 		boolean global
-) implements LogicConfig<LogicTagConfig>
+) implements LogicConfig
 {
 	public static final LogicTagConfig DEFAULT = new LogicTagConfig(
 			true,
@@ -48,7 +48,7 @@ public record LogicTagConfig(
 	);
 	
 	@Override
-	public LogicType<?, LogicTagConfig> type()
+	public LogicType type()
 	{
 		return LBRLogicTypes.TAG.get();
 	}

--- a/src/main/java/net/swedz/little_big_redstone/network/packet/WriteLogicConfigPacket.java
+++ b/src/main/java/net/swedz/little_big_redstone/network/packet/WriteLogicConfigPacket.java
@@ -11,7 +11,7 @@ import net.swedz.little_big_redstone.network.LBRCustomPacket;
 import net.swedz.tesseract.neoforge.packet.PacketContext;
 
 public record WriteLogicConfigPacket(
-		LogicConfig<?> config
+		LogicConfig config
 ) implements LBRCustomPacket
 {
 	public static final StreamCodec<ByteBuf, WriteLogicConfigPacket> STREAM_CODEC = StreamCodec.composite(


### PR DESCRIPTION
A few additional things to note:

- The `Item` associated with a `LogicType` are always assumed to have the same namespace and path of the `LogicType`.
- The logic component font that is used in sticky notes will use the namespace of the `LogicType`. This is so that multiple sources can add as many `LogicType`s as they want without symbols potentially colliding.
- If no namespace is provided in a data value (such as in an item component) for referencing a `LogicType`, the `little_big_redstone` namespace will be used. This is so old data (which had no namespace, obviously) will properly convert to the `little_big_redstone` namespace after updating.
- Removes generics from `LogicType` and `LogicConfig` as they are not useful and just creates more problems.