### PR TITLE
Rename LogicPortHolder methods to not accidentally override methods elsewhere

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderer.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/logic/LogicRenderer.java
@@ -49,13 +49,13 @@ public abstract class LogicRenderer<L extends LogicComponent<L, C>, C extends Lo
 				outputAlpha = 1;
 			}
 			
-			int inputs = component.inputs();
+			int inputs = component.inputPorts();
 			for(int i = 0; i < inputs; i++)
 			{
 				this.renderPort(graphics, x, y, size, true, i, inputs, red, green, blue, inputAlpha);
 			}
 			
-			int outputs = component.outputs();
+			int outputs = component.outputPorts();
 			for(int i = 0; i < outputs; i++)
 			{
 				this.renderPort(graphics, x, y, size, false, i, outputs, red, green, blue, outputAlpha);

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/widget/MicrochipWidget.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/widget/MicrochipWidget.java
@@ -42,7 +42,6 @@ import net.swedz.tesseract.neoforge.helper.guigraphics.TesseractGuiGraphics;
 import net.swedz.tesseract.neoforge.proxy.Proxies;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 public final class MicrochipWidget implements GuiEventListener, Renderable, NarratableEntry
 {
@@ -145,7 +144,7 @@ public final class MicrochipWidget implements GuiEventListener, Renderable, Narr
 		if(this.hasSelectedPort())
 		{
 			var component = microchip.components().get(selectedPort.slot());
-			if(component == null || selectedPort.index() >= component.component().outputs())
+			if(component == null || selectedPort.index() >= component.component().outputPorts())
 			{
 				selectedPort = null;
 				LBR.LOGGER.info("Cleared selected port because it doesn't exist anymore");
@@ -571,7 +570,7 @@ public final class MicrochipWidget implements GuiEventListener, Renderable, Narr
 		var logicConfig = logicComponent.config();
 		List<Component> lines = Lists.newArrayList();
 		lines.add(logicConfig.type().displayName().withStyle(Style.EMPTY.withUnderlined(true)));
-		logicConfig.type().tooltip(logicConfig, false, true, false).ifPresent((Consumer<List<Component>>) lines::addAll);
+		logicConfig.type().tooltip(logicConfig, false, true, false).ifPresent(lines::addAll);
 		if(logicConfig.hasMenu())
 		{
 			lines.add(Component.empty());

--- a/src/main/java/net/swedz/little_big_redstone/gui/microchip/wire/WirePathKey.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/microchip/wire/WirePathKey.java
@@ -35,9 +35,9 @@ public record WirePathKey(
 		return new WirePathKey(
 				Optional.of(wire),
 				output.size().wireOutStartX(outputX),
-				output.size().wireOutStartY(outputY, outputIndex, output.component().outputs()),
+				output.size().wireOutStartY(outputY, outputIndex, output.component().outputPorts()),
 				input.size().wireInEndX(inputX),
-				input.size().wireInEndY(inputY, inputIndex, input.component().inputs()),
+				input.size().wireInEndY(inputY, inputIndex, input.component().inputPorts()),
 				Optional.empty()
 		);
 	}
@@ -60,7 +60,7 @@ public record WirePathKey(
 		}
 		
 		int startX = outputLogic.size().wireOutStartX(outputLogic.x());
-		int startY = outputLogic.size().wireOutStartY(outputLogic.y(), selectedPort.index(), outputLogic.component().outputs());
+		int startY = outputLogic.size().wireOutStartY(outputLogic.y(), selectedPort.index(), outputLogic.component().outputPorts());
 		
 		return new WirePathKey(
 				Optional.empty(),
@@ -102,9 +102,9 @@ public record WirePathKey(
 		return new WirePathKey(
 				Optional.empty(),
 				outputLogicPorts.size().wireOutStartX(outputX),
-				outputLogicPorts.size().wireOutStartY(outputY, outputIndex, outputLogicPorts.outputs()),
+				outputLogicPorts.size().wireOutStartY(outputY, outputIndex, outputLogicPorts.outputPorts()),
 				inputLogicPorts.size().wireInEndX(inputX),
-				inputLogicPorts.size().wireInEndY(inputY, inputIndex, inputLogicPorts.inputs()),
+				inputLogicPorts.size().wireInEndY(inputY, inputIndex, inputLogicPorts.inputPorts()),
 				Optional.of(additionalAvoidBounds)
 		);
 	}

--- a/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
+++ b/src/main/java/net/swedz/little_big_redstone/guide/tags/microchip/MicrochipGuidebookScene.java
@@ -273,7 +273,7 @@ public final class MicrochipGuidebookScene extends LytBox implements ExportableR
 			return;
 		}
 		var fromLogic = microchip.components().get(fromSlot);
-		if(fromLogic.component().outputs() <= fromPort)
+		if(fromLogic.component().outputPorts() <= fromPort)
 		{
 			errorSink.appendError(compiler, "Logic with name '" + from + "' does not have an output port for that index", el);
 			return;
@@ -286,7 +286,7 @@ public final class MicrochipGuidebookScene extends LytBox implements ExportableR
 			return;
 		}
 		var toLogic = microchip.components().get(toSlot);
-		if(toLogic.component().inputs() <= toPort)
+		if(toLogic.component().inputPorts() <= toPort)
 		{
 			errorSink.appendError(compiler, "Logic with name '" + from + "' does not have an input port for that index", el);
 			return;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/Microchip.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/Microchip.java
@@ -241,7 +241,7 @@ public final class Microchip
 		for(var entry : components.traversal())
 		{
 			int inputSlot = entry.slot();
-			int totalInputs = entry.component().inputs();
+			int totalInputs = entry.component().inputPorts();
 			int[] inputs = new int[totalInputs];
 			outer:
 			for(int inputPort = 0; inputPort < totalInputs; inputPort++)
@@ -432,10 +432,10 @@ public final class Microchip
 				var outputComponent = components.get(wire.output().slot());
 				var inputComponent = components.get(wire.input().slot());
 				// Check that a port exists at the output index
-				if(wire.output().index() >= outputComponent.component().outputs() ||
+				if(wire.output().index() >= outputComponent.component().outputPorts() ||
 				   wire.output().index() < 0 ||
 				   // Check that a port exists at the input index
-				   wire.input().index() >= inputComponent.component().inputs() ||
+				   wire.input().index() >= inputComponent.component().inputPorts() ||
 				   wire.input().index() < 0)
 				{
 					return false;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
@@ -75,27 +75,27 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 	public abstract LogicType type();
 	
 	@Override
-	public final IntRange inputsAllowed()
+	public final IntRange inputPortsAllowed()
 	{
-		return config.inputsAllowed();
+		return config.inputPortsAllowed();
 	}
 	
 	@Override
-	public final int inputs()
+	public final int inputPorts()
 	{
-		return config.inputs();
+		return config.inputPorts();
 	}
 	
 	@Override
-	public final IntRange outputsAllowed()
+	public final IntRange outputPortsAllowed()
 	{
-		return config.outputsAllowed();
+		return config.outputPortsAllowed();
 	}
 	
 	@Override
-	public final int outputs()
+	public final int outputPorts()
 	{
-		return config.outputs();
+		return config.outputPorts();
 	}
 	
 	@Override
@@ -108,7 +108,7 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 	
 	public final void processTick(LogicTickingContext context, int[] inputs)
 	{
-		int expectedInputs = this.inputs();
+		int expectedInputs = this.inputPorts();
 		Assert.that(expectedInputs == inputs.length, "Mismatching logic component input sizes: expected %d but got %d".formatted(expectedInputs, inputs.length));
 		if(configValid == null)
 		{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponents.java
@@ -69,7 +69,7 @@ public final class LogicComponents extends MicrochipObjectContainer<LogicEntry, 
 		var size = entry.size();
 		LogicSelectedPort nearest = null;
 		int nearestDistance = 0;
-		int totalPorts = input ? entry.component().inputs() : entry.component().outputs();
+		int totalPorts = input ? entry.component().inputPorts() : entry.component().outputPorts();
 		for(int index = 0; index < totalPorts; index++)
 		{
 			int portX = size.portX(entry.x(), input, index, totalPorts);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicPortHolder.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicPortHolder.java
@@ -4,17 +4,17 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 
 public interface LogicPortHolder
 {
-	IntRange inputsAllowed();
+	IntRange inputPortsAllowed();
 	
-	int inputs();
+	int inputPorts();
 	
-	IntRange outputsAllowed();
+	IntRange outputPortsAllowed();
 	
-	int outputs();
+	int outputPorts();
 	
 	default LogicGridSize size()
 	{
-		int ports = Math.max(this.inputs(), this.outputs());
+		int ports = Math.max(this.inputPorts(), this.outputPorts());
 		return new LogicGridSize(1, Math.max(1, ports / 2));
 	}
 }

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTraversal.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTraversal.java
@@ -39,7 +39,7 @@ public final class LogicTraversal
 		List<LogicEntry> starts = Lists.newArrayList();
 		for(var entry : microchip.components())
 		{
-			if(entry.component().inputs() == 0 || microchip.wires().getByInputSlot(entry.slot()).isEmpty())
+			if(entry.component().inputPorts() == 0 || microchip.wires().getByInputSlot(entry.slot()).isEmpty())
 			{
 				order.add(entry);
 				starts.add(entry);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
@@ -47,25 +47,25 @@ public record LogicCalculatorConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(2, 10);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return inputs;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfigMenuProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfigMenuProvider.java
@@ -27,7 +27,7 @@ final class LogicCalculatorConfigMenuProvider extends LogicConfigMenuProvider<Lo
 				config.mode(),
 				Arrays.asList(LogicCalculatorMode.values()),
 				LogicCalculatorMode::label,
-				(value) -> config = new LogicCalculatorConfig(value, config.inputs())
+				(value) -> config = new LogicCalculatorConfig(value, config.inputPorts())
 		);
 	}
 	
@@ -43,7 +43,7 @@ final class LogicCalculatorConfigMenuProvider extends LogicConfigMenuProvider<Lo
 				18,
 				2,
 				10,
-				config.inputs(),
+				config.inputPorts(),
 				1,
 				0,
 				(value) -> config = new LogicCalculatorConfig(config.mode(), (int) Math.round(value))

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
@@ -57,25 +57,25 @@ public record LogicComparatorConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 11);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return inputs + (signalStrength == 0 ? 1 : 0);
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebuggerConfig.java
@@ -23,25 +23,25 @@ public record LogicDebuggerConfig() implements LogicConfig
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(0, 0);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 0;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(0, 0);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 0;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
@@ -39,34 +39,39 @@ public abstract class MultiLogicGateConfig<C extends MultiLogicGateConfig<C>> im
 	
 	public MultiLogicGateConfig(int inputs)
 	{
-		this.inputs = this.inputsAllowed().clamp(inputs);
+		this.inputs = this.inputPortsAllowed().clamp(inputs);
 	}
 	
 	public MultiLogicGateConfig()
 	{
-		this.inputs = this.inputsAllowed().min();
+		this.inputs = this.inputPortsAllowed().min();
 	}
 	
-	@Override
-	public IntRange inputsAllowed()
-	{
-		return new IntRange(2, 10);
-	}
-	
-	@Override
 	public int inputs()
 	{
 		return inputs;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public final IntRange inputPortsAllowed()
+	{
+		return new IntRange(2, 10);
+	}
+	
+	@Override
+	public final int inputPorts()
+	{
+		return inputs;
+	}
+	
+	@Override
+	public final IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public final int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfigMenuProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfigMenuProvider.java
@@ -28,9 +28,9 @@ final class MultiLogicGateConfigMenuProvider<C extends MultiLogicGateConfig<C>> 
 				0,
 				width,
 				18,
-				config.inputsAllowed().min(),
-				config.inputsAllowed().max(),
-				config.inputs(),
+				config.inputPortsAllowed().min(),
+				config.inputPortsAllowed().max(),
+				config.inputPorts(),
 				1,
 				0,
 				(value) -> config = mutator.apply((int) Math.round(value))

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/SingleLogicGateConfig.java
@@ -6,25 +6,25 @@ import net.swedz.tesseract.neoforge.api.range.IntRange;
 public interface SingleLogicGateConfig<C extends SingleLogicGateConfig<C>> extends LogicConfig
 {
 	@Override
-	default IntRange inputsAllowed()
+	default IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	default int inputs()
+	default int inputPorts()
 	{
 		return 1;
 	}
 	
 	@Override
-	default IntRange outputsAllowed()
+	default IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	default int outputs()
+	default int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
@@ -79,25 +79,25 @@ public record LogicIOConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return input ? new IntRange(0, 0) : new IntRange(1, 1);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return input ? 0 : 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return input ? new IntRange(1, 1) : new IntRange(0, 0);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return input ? 1 : 0;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
@@ -27,25 +27,25 @@ public record RSNORLatchConfig() implements LogicConfig
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(2, 2);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 2;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
@@ -27,25 +27,25 @@ public record TFlipFlopConfig() implements LogicConfig
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
@@ -46,25 +46,25 @@ public record PulseThrottlerConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
@@ -71,7 +71,7 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 		int input = inputs[0];
 		if(input > 0 && RANDOM.nextFloat() <= config.chance())
 		{
-			outputIndex = RANDOM.nextInt(config.outputs());
+			outputIndex = RANDOM.nextInt(config.outputPorts());
 			outputState = input;
 		}
 		else

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
@@ -71,25 +71,25 @@ public record LogicRandomizerConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 10);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return outputs;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfigMenuProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfigMenuProvider.java
@@ -22,9 +22,9 @@ final class LogicRandomizerConfigMenuProvider extends LogicConfigMenuProvider<Lo
 				0,
 				width,
 				18,
-				config.outputsAllowed().min(),
-				config.outputsAllowed().max(),
-				config.outputs(),
+				config.outputPortsAllowed().min(),
+				config.outputPortsAllowed().max(),
+				config.outputPorts(),
 				1,
 				0,
 				(value) -> config = new LogicRandomizerConfig((int) Math.round(value), config.chance())
@@ -46,7 +46,7 @@ final class LogicRandomizerConfigMenuProvider extends LogicConfigMenuProvider<Lo
 				config.chance() * 100,
 				1,
 				0,
-				(value) -> config = new LogicRandomizerConfig(config.outputs(), (float) (value / 100f))
+				(value) -> config = new LogicRandomizerConfig(config.outputPorts(), (float) (value / 100f))
 		);
 	}
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
@@ -61,25 +61,25 @@ public record LogicReaderConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(0, 0);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return 0;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
@@ -76,13 +76,13 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 				newSelected--;
 				if(newSelected < 0)
 				{
-					newSelected = config.outputs() - 1;
+					newSelected = config.outputPorts() - 1;
 				}
 			}
 			if(increment)
 			{
 				newSelected++;
-				if(newSelected >= config.outputs())
+				if(newSelected >= config.outputPorts())
 				{
 					newSelected = 0;
 				}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
@@ -77,25 +77,25 @@ public record LogicSelectorConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(2, 10);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return mode == LogicSelectorMode.COUNTER ? 2 : outputs;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(2, 10);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return outputs;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfigMenuProvider.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfigMenuProvider.java
@@ -32,7 +32,7 @@ final class LogicSelectorConfigMenuProvider extends LogicConfigMenuProvider<Logi
 				LogicSelectorMode::label,
 				(value) ->
 				{
-					config = new LogicSelectorConfig(value, config.outputs(), config.passSignal());
+					config = new LogicSelectorConfig(value, config.outputPorts(), config.passSignal());
 					if(modeButton != null)
 					{
 						modeButton.setTooltip(config.mode().tooltip());
@@ -51,9 +51,9 @@ final class LogicSelectorConfigMenuProvider extends LogicConfigMenuProvider<Logi
 				22,
 				width,
 				18,
-				config.outputsAllowed().min(),
-				config.outputsAllowed().max(),
-				config.outputs(),
+				config.outputPortsAllowed().min(),
+				config.outputPortsAllowed().max(),
+				config.outputPorts(),
 				1,
 				0,
 				(value) -> config = new LogicSelectorConfig(config.mode(), (int) Math.round(value), config.passSignal())
@@ -68,7 +68,7 @@ final class LogicSelectorConfigMenuProvider extends LogicConfigMenuProvider<Logi
 				0,
 				22 * 2,
 				config.passSignal(),
-				(value) -> config = new LogicSelectorConfig(config.mode(), config.outputs(), value)
+				(value) -> config = new LogicSelectorConfig(config.mode(), config.outputPorts(), value)
 		);
 	}
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
@@ -56,25 +56,25 @@ public record LogicSequencerConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return new IntRange(1, 2);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return resetPort ? 2 : 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return new IntRange(1, 1);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return 1;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
@@ -54,25 +54,25 @@ public record LogicTagConfig(
 	}
 	
 	@Override
-	public IntRange inputsAllowed()
+	public IntRange inputPortsAllowed()
 	{
 		return input ? new IntRange(0, 0) : new IntRange(1, 1);
 	}
 	
 	@Override
-	public int inputs()
+	public int inputPorts()
 	{
 		return input ? 0 : 1;
 	}
 	
 	@Override
-	public IntRange outputsAllowed()
+	public IntRange outputPortsAllowed()
 	{
 		return input ? new IntRange(1, 1) : new IntRange(0, 0);
 	}
 	
 	@Override
-	public int outputs()
+	public int outputPorts()
 	{
 		return input ? 1 : 0;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/wire/MicrochipWires.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/wire/MicrochipWires.java
@@ -203,8 +203,8 @@ public final class MicrochipWires implements Iterable<Wire>
 	{
 		int wiresRemoved = 0;
 		int slot = entry.slot();
-		int totalInputs = entry.component().inputs();
-		int totalOutputs = entry.component().outputs();
+		int totalInputs = entry.component().inputPorts();
+		int totalOutputs = entry.component().outputPorts();
 		for(var wire : this.getInvolvingSlot(slot))
 		{
 			if((wire.input().slot() == slot && wire.input().index() >= totalInputs) ||

--- a/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeMicrochipWirePacket.java
+++ b/src/main/java/net/swedz/little_big_redstone/network/packet/PlaceTakeMicrochipWirePacket.java
@@ -59,8 +59,8 @@ public record PlaceTakeMicrochipWirePacket(
 			{
 				var outputLogic = components.get(outputSlot);
 				var inputLogic = components.get(inputSlot);
-				if(outputLogic != null && outputPort < outputLogic.component().outputs() &&
-				   inputLogic != null && inputPort < inputLogic.component().inputs())
+				if(outputLogic != null && outputPort < outputLogic.component().outputPorts() &&
+				   inputLogic != null && inputPort < inputLogic.component().inputPorts())
 				{
 					if(place)
 					{


### PR DESCRIPTION
Fixes an issue introduced in #239 where `LogicComparatorConfig`'s codecs and `LogicComparatorConfigMenuProvider` were using the wrong values accidentally. Hopefully this will prevent future accidents.