### PR TITLE
Use default config field for defining default values in the codec

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculatorConfig.java
@@ -29,8 +29,8 @@ public record LogicCalculatorConfig(
 	
 	public static final MapCodec<LogicCalculatorConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					CodecHelper.forLowercaseEnum(LogicCalculatorMode.class).optionalFieldOf("mode", LogicCalculatorMode.ADDITION).forGetter(LogicCalculatorConfig::mode),
-					Codec.intRange(2, 10).optionalFieldOf("inputs", 2).forGetter(LogicCalculatorConfig::inputs)
+					CodecHelper.forLowercaseEnum(LogicCalculatorMode.class).optionalFieldOf("mode", DEFAULT.mode()).forGetter(LogicCalculatorConfig::mode),
+					Codec.intRange(2, 10).optionalFieldOf("inputs", DEFAULT.inputs()).forGetter(LogicCalculatorConfig::inputs)
 			)
 			.apply(instance, LogicCalculatorConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparatorConfig.java
@@ -35,10 +35,10 @@ public record LogicComparatorConfig(
 	
 	public static final MapCodec<LogicComparatorConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					CodecHelper.forLowercaseEnum(LogicAccumulationMode.class).optionalFieldOf("mode", LogicAccumulationMode.ALL).forGetter(LogicComparatorConfig::mode),
-					Codec.intRange(0, 15).optionalFieldOf("signal_strength", 0).forGetter(LogicComparatorConfig::signalStrength),
-					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("signal_comparison", LogicComparisonMode.GREATER_THAN_OR_EQUAL_TO).forGetter(LogicComparatorConfig::signalComparison),
-					Codec.intRange(1, 10).optionalFieldOf("inputs", 1).forGetter(LogicComparatorConfig::inputs)
+					CodecHelper.forLowercaseEnum(LogicAccumulationMode.class).optionalFieldOf("mode", DEFAULT.mode()).forGetter(LogicComparatorConfig::mode),
+					Codec.intRange(0, 15).optionalFieldOf("signal_strength", DEFAULT.signalStrength()).forGetter(LogicComparatorConfig::signalStrength),
+					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("signal_comparison", DEFAULT.signalComparison()).forGetter(LogicComparatorConfig::signalComparison),
+					Codec.intRange(1, 10).optionalFieldOf("inputs", DEFAULT.inputs()).forGetter(LogicComparatorConfig::inputs)
 			)
 			.apply(instance, LogicComparatorConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ANDGateConfig.java
@@ -14,7 +14,7 @@ public final class ANDGateConfig extends MultiLogicGateConfig<ANDGateConfig>
 {
 	public static final ANDGateConfig DEFAULT = new ANDGateConfig();
 	
-	public static final MapCodec<ANDGateConfig>             CODEC        = codec(ANDGateConfig::new);
+	public static final MapCodec<ANDGateConfig>             CODEC        = codec(DEFAULT, ANDGateConfig::new);
 	public static final StreamCodec<ByteBuf, ANDGateConfig> STREAM_CODEC = streamCodec(ANDGateConfig::new);
 	
 	public ANDGateConfig(int inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/MultiLogicGateConfig.java
@@ -18,11 +18,11 @@ import java.util.function.Function;
 
 public abstract class MultiLogicGateConfig<C extends MultiLogicGateConfig<C>> implements LogicConfig
 {
-	public static <C extends MultiLogicGateConfig<C>> MapCodec<C> codec(Function<Integer, C> creator)
+	public static <C extends MultiLogicGateConfig<C>> MapCodec<C> codec(C defaultConfig, Function<Integer, C> creator)
 	{
 		return RecordCodecBuilder.mapCodec((instance) -> instance
 				.group(
-						Codec.INT.optionalFieldOf("input_count", 2).forGetter(MultiLogicGateConfig::inputs)
+						Codec.INT.optionalFieldOf("input_count", defaultConfig.inputs()).forGetter(MultiLogicGateConfig::inputs)
 				)
 				.apply(instance, creator));
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NANDGateConfig.java
@@ -14,7 +14,7 @@ public final class NANDGateConfig extends MultiLogicGateConfig<NANDGateConfig>
 {
 	public static final NANDGateConfig DEFAULT = new NANDGateConfig();
 	
-	public static final MapCodec<NANDGateConfig>             CODEC        = codec(NANDGateConfig::new);
+	public static final MapCodec<NANDGateConfig>             CODEC        = codec(DEFAULT, NANDGateConfig::new);
 	public static final StreamCodec<ByteBuf, NANDGateConfig> STREAM_CODEC = streamCodec(NANDGateConfig::new);
 	
 	public NANDGateConfig(int inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NORGateConfig.java
@@ -14,7 +14,7 @@ public final class NORGateConfig extends MultiLogicGateConfig<NORGateConfig>
 {
 	public static final NORGateConfig DEFAULT = new NORGateConfig();
 	
-	public static final MapCodec<NORGateConfig>             CODEC        = codec(NORGateConfig::new);
+	public static final MapCodec<NORGateConfig>             CODEC        = codec(DEFAULT, NORGateConfig::new);
 	public static final StreamCodec<ByteBuf, NORGateConfig> STREAM_CODEC = streamCodec(NORGateConfig::new);
 	
 	public NORGateConfig(int inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/NOTGateConfig.java
@@ -12,7 +12,8 @@ import java.util.List;
 
 public record NOTGateConfig() implements SingleLogicGateConfig<NOTGateConfig>
 {
-	public static final NOTGateConfig                       DEFAULT      = new NOTGateConfig();
+	public static final NOTGateConfig DEFAULT = new NOTGateConfig();
+	
 	public static final MapCodec<NOTGateConfig>             CODEC        = MapCodec.unit(DEFAULT);
 	public static final StreamCodec<ByteBuf, NOTGateConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/ORGateConfig.java
@@ -14,7 +14,7 @@ public final class ORGateConfig extends MultiLogicGateConfig<ORGateConfig>
 {
 	public static final ORGateConfig DEFAULT = new ORGateConfig();
 	
-	public static final MapCodec<ORGateConfig>             CODEC        = codec(ORGateConfig::new);
+	public static final MapCodec<ORGateConfig>             CODEC        = codec(DEFAULT, ORGateConfig::new);
 	public static final StreamCodec<ByteBuf, ORGateConfig> STREAM_CODEC = streamCodec(ORGateConfig::new);
 	
 	public ORGateConfig(int inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/config/XORGateConfig.java
@@ -14,7 +14,7 @@ public final class XORGateConfig extends MultiLogicGateConfig<XORGateConfig>
 {
 	public static final XORGateConfig DEFAULT = new XORGateConfig();
 	
-	public static final MapCodec<XORGateConfig>             CODEC        = codec(XORGateConfig::new);
+	public static final MapCodec<XORGateConfig>             CODEC        = codec(DEFAULT, XORGateConfig::new);
 	public static final StreamCodec<ByteBuf, XORGateConfig> STREAM_CODEC = streamCodec(XORGateConfig::new);
 	
 	public XORGateConfig(int inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIOConfig.java
@@ -29,13 +29,21 @@ public record LogicIOConfig(
 		LogicPowerOutputType powerType
 ) implements LogicConfig
 {
+	public static final LogicIOConfig DEFAULT = new LogicIOConfig(
+			true,
+			Direction.NORTH,
+			1,
+			LogicComparisonMode.GREATER_THAN_OR_EQUAL_TO,
+			LogicPowerOutputType.WEAK
+	);
+	
 	public static final MapCodec<LogicIOConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					Codec.BOOL.optionalFieldOf("input", true).forGetter(LogicIOConfig::input),
-					Direction.CODEC.optionalFieldOf("direction", Direction.NORTH).forGetter(LogicIOConfig::direction),
-					Codec.intRange(0, 15).optionalFieldOf("signal_strength", 0).forGetter(LogicIOConfig::signalStrength),
-					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("signal_comparison", LogicComparisonMode.GREATER_THAN_OR_EQUAL_TO).forGetter(LogicIOConfig::signalComparison),
-					CodecHelper.forLowercaseEnum(LogicPowerOutputType.class).optionalFieldOf("power_type", LogicPowerOutputType.WEAK).forGetter(LogicIOConfig::powerType)
+					Codec.BOOL.optionalFieldOf("input", DEFAULT.input()).forGetter(LogicIOConfig::input),
+					Direction.CODEC.optionalFieldOf("direction", DEFAULT.direction()).forGetter(LogicIOConfig::direction),
+					Codec.intRange(0, 15).optionalFieldOf("signal_strength", DEFAULT.signalStrength()).forGetter(LogicIOConfig::signalStrength),
+					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("signal_comparison", DEFAULT.signalComparison()).forGetter(LogicIOConfig::signalComparison),
+					CodecHelper.forLowercaseEnum(LogicPowerOutputType.class).optionalFieldOf("power_type", DEFAULT.powerType()).forGetter(LogicIOConfig::powerType)
 			)
 			.apply(instance, LogicIOConfig::new));
 	
@@ -46,14 +54,6 @@ public record LogicIOConfig(
 			CodecHelper.forEnumStream(LogicComparisonMode.class), LogicIOConfig::signalComparison,
 			CodecHelper.forEnumStream(LogicPowerOutputType.class), LogicIOConfig::powerType,
 			LogicIOConfig::new
-	);
-	
-	public static final LogicIOConfig DEFAULT = new LogicIOConfig(
-			true,
-			Direction.NORTH,
-			1,
-			LogicComparisonMode.GREATER_THAN_OR_EQUAL_TO,
-			LogicPowerOutputType.WEAK
 	);
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatchConfig.java
@@ -16,8 +16,7 @@ public record RSNORLatchConfig() implements LogicConfig
 {
 	public static final RSNORLatchConfig DEFAULT = new RSNORLatchConfig();
 	
-	public static final MapCodec<RSNORLatchConfig> CODEC = MapCodec.unit(DEFAULT);
-	
+	public static final MapCodec<RSNORLatchConfig>             CODEC        = MapCodec.unit(DEFAULT);
 	public static final StreamCodec<ByteBuf, RSNORLatchConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlopConfig.java
@@ -16,8 +16,7 @@ public record TFlipFlopConfig() implements LogicConfig
 {
 	public static final TFlipFlopConfig DEFAULT = new TFlipFlopConfig();
 	
-	public static final MapCodec<TFlipFlopConfig> CODEC = MapCodec.unit(DEFAULT);
-	
+	public static final MapCodec<TFlipFlopConfig>             CODEC        = MapCodec.unit(DEFAULT);
 	public static final StreamCodec<ByteBuf, TFlipFlopConfig> STREAM_CODEC = StreamCodec.unit(DEFAULT);
 	
 	@Override

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottlerConfig.java
@@ -28,8 +28,8 @@ public record PulseThrottlerConfig(
 	
 	public static final MapCodec<PulseThrottlerConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					Codec.LONG.optionalFieldOf("duration", 1L).forGetter(PulseThrottlerConfig::outputDuration),
-					Codec.intRange(0, 15).optionalFieldOf("signal_strength", 0).forGetter(PulseThrottlerConfig::signalStrength)
+					Codec.LONG.optionalFieldOf("duration", DEFAULT.outputDuration()).forGetter(PulseThrottlerConfig::outputDuration),
+					Codec.intRange(0, 15).optionalFieldOf("signal_strength", DEFAULT.signalStrength()).forGetter(PulseThrottlerConfig::signalStrength)
 			)
 			.apply(instance, PulseThrottlerConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizerConfig.java
@@ -28,8 +28,8 @@ public record LogicRandomizerConfig(
 	
 	public static final MapCodec<LogicRandomizerConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					Codec.intRange(1, 10).optionalFieldOf("outputs", 1).forGetter(LogicRandomizerConfig::outputs),
-					Codec.FLOAT.optionalFieldOf("chance", 1f).forGetter(LogicRandomizerConfig::chance)
+					Codec.intRange(1, 10).optionalFieldOf("outputs", DEFAULT.outputs()).forGetter(LogicRandomizerConfig::outputs),
+					Codec.FLOAT.optionalFieldOf("chance", DEFAULT.chance()).forGetter(LogicRandomizerConfig::chance)
 			)
 			.apply(instance, LogicRandomizerConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReaderConfig.java
@@ -37,11 +37,11 @@ public record LogicReaderConfig(
 	
 	public static final MapCodec<LogicReaderConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					CodecHelper.forLowercaseEnum(LogicReaderMode.class).optionalFieldOf("mode", LogicReaderMode.ITEM).forGetter(LogicReaderConfig::mode),
-					Direction.CODEC.optionalFieldOf("direction", Direction.NORTH).forGetter(LogicReaderConfig::direction),
-					LogicReaderThreshold.CODEC.optionalFieldOf("fill_threshold", LogicReaderThreshold.DEFAULT).forGetter(LogicReaderConfig::fillThreshold),
-					Codec.intRange(1, 15).optionalFieldOf("signal_threshold", 1).forGetter(LogicReaderConfig::signalThreshold),
-					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("comparison", LogicComparisonMode.GREATER_THAN_OR_EQUAL_TO).forGetter(LogicReaderConfig::comparison)
+					CodecHelper.forLowercaseEnum(LogicReaderMode.class).optionalFieldOf("mode", DEFAULT.mode()).forGetter(LogicReaderConfig::mode),
+					Direction.CODEC.optionalFieldOf("direction", DEFAULT.direction()).forGetter(LogicReaderConfig::direction),
+					LogicReaderThreshold.CODEC.optionalFieldOf("fill_threshold", DEFAULT.fillThreshold()).forGetter(LogicReaderConfig::fillThreshold),
+					Codec.intRange(1, 15).optionalFieldOf("signal_threshold", DEFAULT.signalThreshold()).forGetter(LogicReaderConfig::signalThreshold),
+					CodecHelper.forLowercaseEnum(LogicComparisonMode.class).optionalFieldOf("comparison", DEFAULT.comparison()).forGetter(LogicReaderConfig::comparison)
 			)
 			.apply(instance, LogicReaderConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelectorConfig.java
@@ -31,9 +31,9 @@ public record LogicSelectorConfig(
 	
 	public static final MapCodec<LogicSelectorConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					CodecHelper.forLowercaseEnum(LogicSelectorMode.class).optionalFieldOf("mode", LogicSelectorMode.COUNTER).forGetter(LogicSelectorConfig::mode),
-					Codec.intRange(2, 10).optionalFieldOf("outputs", 2).forGetter(LogicSelectorConfig::outputs),
-					Codec.BOOL.optionalFieldOf("pass_signal", true).forGetter(LogicSelectorConfig::passSignal)
+					CodecHelper.forLowercaseEnum(LogicSelectorMode.class).optionalFieldOf("mode", DEFAULT.mode()).forGetter(LogicSelectorConfig::mode),
+					Codec.intRange(2, 10).optionalFieldOf("outputs", DEFAULT.outputs()).forGetter(LogicSelectorConfig::outputs),
+					Codec.BOOL.optionalFieldOf("pass_signal", DEFAULT.passSignal()).forGetter(LogicSelectorConfig::passSignal)
 			)
 			.apply(instance, LogicSelectorConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencerConfig.java
@@ -34,10 +34,10 @@ public record LogicSequencerConfig(
 	
 	public static final MapCodec<LogicSequencerConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					CodecHelper.forLowercaseEnum(LogicSequencerMode.class).optionalFieldOf("mode", LogicSequencerMode.WEAK).forGetter(LogicSequencerConfig::mode),
-					Codec.LONG.optionalFieldOf("delay", 20L).forGetter(LogicSequencerConfig::outputDelay),
-					Codec.BOOL.optionalFieldOf("auto_reset", false).forGetter(LogicSequencerConfig::autoReset),
-					Codec.BOOL.optionalFieldOf("reset_port", false).forGetter(LogicSequencerConfig::resetPort)
+					CodecHelper.forLowercaseEnum(LogicSequencerMode.class).optionalFieldOf("mode", DEFAULT.mode()).forGetter(LogicSequencerConfig::mode),
+					Codec.LONG.optionalFieldOf("delay", DEFAULT.outputDelay()).forGetter(LogicSequencerConfig::outputDelay),
+					Codec.BOOL.optionalFieldOf("auto_reset", DEFAULT.autoReset()).forGetter(LogicSequencerConfig::autoReset),
+					Codec.BOOL.optionalFieldOf("reset_port", DEFAULT.resetPort()).forGetter(LogicSequencerConfig::resetPort)
 			)
 			.apply(instance, LogicSequencerConfig::new));
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTagConfig.java
@@ -32,10 +32,10 @@ public record LogicTagConfig(
 	
 	public static final MapCodec<LogicTagConfig> CODEC = RecordCodecBuilder.mapCodec((instance) -> instance
 			.group(
-					Codec.BOOL.optionalFieldOf("input", true).forGetter(LogicTagConfig::input),
-					LogicTagLabel.CODEC.optionalFieldOf("label", LogicTagLabel.EMPTY).forGetter(LogicTagConfig::label),
-					Codec.intRange(1, 100).optionalFieldOf("threshold", 1).forGetter(LogicTagConfig::threshold),
-					Codec.BOOL.optionalFieldOf("global", false).forGetter(LogicTagConfig::global)
+					Codec.BOOL.optionalFieldOf("input", DEFAULT.input()).forGetter(LogicTagConfig::input),
+					LogicTagLabel.CODEC.optionalFieldOf("label", DEFAULT.label()).forGetter(LogicTagConfig::label),
+					Codec.intRange(1, 100).optionalFieldOf("threshold", DEFAULT.threshold()).forGetter(LogicTagConfig::threshold),
+					Codec.BOOL.optionalFieldOf("global", DEFAULT.global()).forGetter(LogicTagConfig::global)
 			)
 			.apply(instance, LogicTagConfig::new));
 	


### PR DESCRIPTION
Reduces duplication and helps prevent accidents