### PR TITLE
Restrict logic ticking context access

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicComponent.java
@@ -104,7 +104,7 @@ public abstract class LogicComponent<L extends LogicComponent<L, C>, C extends L
 		return config.size();
 	}
 	
-	protected abstract void processTickInternal(LogicTickingContext context, int[] inputs);
+	protected abstract void processTickInternal(LogicContextAccess context, int[] inputs);
 	
 	public final void processTick(LogicTickingContext context, int[] inputs)
 	{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicContextAccess.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicContextAccess.java
@@ -2,6 +2,8 @@ package net.swedz.little_big_redstone.microchip.object.logic;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
+import net.swedz.little_big_redstone.microchip.awareness.MicrochipAwareness;
 import net.swedz.tesseract.neoforge.api.WorldPos;
 
 import java.util.UUID;
@@ -18,4 +20,10 @@ public interface LogicContextAccess
 	}
 	
 	UUID placedBy();
+	
+	boolean isDebug();
+	
+	<A extends MicrochipAwareness<A>> A awareness(AwarenessType<A> type);
+	
+	void markDirty(LogicComponent component);
 }

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTickingContext.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/LogicTickingContext.java
@@ -55,6 +55,13 @@ public final class LogicTickingContext implements LogicContextAccess
 		return placedBy;
 	}
 	
+	@Override
+	public boolean isDebug()
+	{
+		return microchip.isDebug();
+	}
+	
+	@Override
 	public <A extends MicrochipAwareness<A>> A awareness(AwarenessType<A> type)
 	{
 		return microchip.awarenesses().get(type);
@@ -65,6 +72,7 @@ public final class LogicTickingContext implements LogicContextAccess
 		return !dirtyEntries.isEmpty();
 	}
 	
+	@Override
 	public void markDirty(LogicComponent component)
 	{
 		for(var entry : microchip.components())

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/calculator/LogicCalculator.java
@@ -10,7 +10,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Objects;
@@ -59,7 +59,7 @@ public final class LogicCalculator extends LogicComponent<LogicCalculator, Logic
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/comparator/LogicComparator.java
@@ -9,7 +9,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicAccumulationMode;
 
@@ -59,7 +59,7 @@ public final class LogicComparator extends LogicComponent<LogicComparator, Logic
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/debug/LogicDebugger.java
@@ -8,7 +8,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Objects;
@@ -44,7 +44,7 @@ public final class LogicDebugger extends LogicComponent<LogicDebugger, LogicDebu
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 	}
 	

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ANDGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ANDGateConfig;
 
@@ -40,7 +40,7 @@ public final class ANDGate extends LogicGate<ANDGate, ANDGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		int greatest = 0;
 		for(int input : inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/LogicGate.java
@@ -9,7 +9,7 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.config.LogicConfig;
 
 import java.util.Optional;
@@ -71,10 +71,10 @@ public abstract class LogicGate<G extends LogicGate<G, C>, C extends LogicConfig
 		this.outputState = outputState;
 	}
 	
-	protected abstract int processInputs(LogicTickingContext context, int[] inputs);
+	protected abstract int processInputs(LogicContextAccess context, int[] inputs);
 	
 	@Override
-	public final void processTickInternal(LogicTickingContext context, int[] inputs)
+	public final void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		outputState = this.processInputs(context, inputs);

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NANDGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NANDGateConfig;
 
@@ -40,7 +40,7 @@ public final class NANDGate extends LogicGate<NANDGate, NANDGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		for(int input : inputs)
 		{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NORGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NORGateConfig;
 
@@ -40,7 +40,7 @@ public final class NORGate extends LogicGate<NORGate, NORGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		for(int input : inputs)
 		{

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/NOTGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.NOTGateConfig;
 
@@ -35,7 +35,7 @@ public final class NOTGate extends LogicGate<NOTGate, NOTGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		return inputs[0] == 0 ? 1 : 0;
 	}

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/ORGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.ORGateConfig;
 
@@ -40,7 +40,7 @@ public final class ORGate extends LogicGate<ORGate, ORGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		int greatest = 0;
 		for(int input : inputs)

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/gate/XORGate.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.object.logic.gate.config.XORGateConfig;
 
@@ -40,7 +40,7 @@ public final class XORGate extends LogicGate<XORGate, XORGateConfig>
 	}
 	
 	@Override
-	public int processInputs(LogicTickingContext context, int[] inputs)
+	public int processInputs(LogicContextAccess context, int[] inputs)
 	{
 		int trueCount = 0;
 		int greatest = 0;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/io/LogicIO.java
@@ -12,7 +12,7 @@ import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Objects;
@@ -63,7 +63,7 @@ public final class LogicIO extends LogicComponent<LogicIO, LogicIOConfig> implem
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		boolean powerChanged = false;
 		int originalOutputState = outputState;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/rs/RSNORLatch.java
@@ -9,7 +9,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Objects;
@@ -50,7 +50,7 @@ public final class RSNORLatch extends LogicComponent<RSNORLatch, RSNORLatchConfi
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		int set = inputs[0];

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/latch/tflipflop/TFlipFlop.java
@@ -9,7 +9,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Objects;
@@ -54,7 +54,7 @@ public final class TFlipFlop extends LogicComponent<TFlipFlop, TFlipFlopConfig>
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int input = inputs[0];
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/pulse/PulseThrottler.java
@@ -10,7 +10,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Optional;
@@ -89,7 +89,7 @@ public final class PulseThrottler extends LogicComponent<PulseThrottler, PulseTh
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/randomizer/LogicRandomizer.java
@@ -11,7 +11,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Optional;
@@ -64,7 +64,7 @@ public final class LogicRandomizer extends LogicComponent<LogicRandomizer, Logic
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputIndex = outputIndex;
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/reader/LogicReader.java
@@ -15,7 +15,7 @@ import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.tesseract.neoforge.proxy.Proxies;
 
@@ -71,7 +71,7 @@ public final class LogicReader extends LogicComponent<LogicReader, LogicReaderCo
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/selector/LogicSelector.java
@@ -10,7 +10,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Optional;
@@ -61,7 +61,7 @@ public final class LogicSelector extends LogicComponent<LogicSelector, LogicSele
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalSelected = selected;
 		int originalOutputState = outputState;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/sequencer/LogicSequencer.java
@@ -10,7 +10,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.DyeColor;
 import net.swedz.little_big_redstone.LBRLogicTypes;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 
 import java.util.Optional;
@@ -74,7 +74,7 @@ public final class LogicSequencer extends LogicComponent<LogicSequencer, LogicSe
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		long originalProcessedTicks = processedTicks;
 		boolean originalOutputState = outputState;

--- a/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
+++ b/src/main/java/net/swedz/little_big_redstone/microchip/object/logic/tag/LogicTag.java
@@ -12,7 +12,7 @@ import net.swedz.little_big_redstone.microchip.awareness.AwarenessType;
 import net.swedz.little_big_redstone.microchip.awareness.AwarenessTypes;
 import net.swedz.little_big_redstone.microchip.awareness.MicrochipAware;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicComponent;
-import net.swedz.little_big_redstone.microchip.object.logic.LogicTickingContext;
+import net.swedz.little_big_redstone.microchip.object.logic.LogicContextAccess;
 import net.swedz.little_big_redstone.microchip.object.logic.LogicType;
 import net.swedz.little_big_redstone.microchip.tag.MicrochipTagSystem;
 import net.swedz.little_big_redstone.microchip.tag.TagOwnerKey;
@@ -71,7 +71,7 @@ public final class LogicTag extends LogicComponent<LogicTag, LogicTagConfig> imp
 	}
 	
 	@Override
-	protected void processTickInternal(LogicTickingContext context, int[] inputs)
+	protected void processTickInternal(LogicContextAccess context, int[] inputs)
 	{
 		int originalOutputState = outputState;
 		


### PR DESCRIPTION
Didn't realize I wasn't doing this already. Other data shouldn't be accessed in logic ticking