### PR TITLE
Fix #311: Logic config menu closes instantly when Microchip is on Sable sublevel

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/MicrochipLogicConfigReference.java
+++ b/src/main/java/net/swedz/little_big_redstone/gui/logicconfig/reference/MicrochipLogicConfigReference.java
@@ -71,6 +71,6 @@ public record MicrochipLogicConfigReference(
 	@Override
 	public boolean isStillValid(Player player)
 	{
-		return player.blockPosition().closerThan(pos, 10);
+		return player.distanceToSqr(pos.getCenter()) < 10 * 10;
 	}
 }


### PR DESCRIPTION
Fixes #311 