### PR TITLE
Fix #316: Crash when empty crafting input checks for reset logic recipes

### DIFF
--- a/src/main/java/net/swedz/little_big_redstone/recipe/TransmuteWithoutMaterialRecipe.java
+++ b/src/main/java/net/swedz/little_big_redstone/recipe/TransmuteWithoutMaterialRecipe.java
@@ -60,7 +60,7 @@ public final class TransmuteWithoutMaterialRecipe extends NormalCraftingRecipe
 	@Override
 	public boolean matches(CraftingInput input, Level level)
 	{
-		return ingredient.test(input.getItem(0));
+		return !input.items().isEmpty() && ingredient.test(input.getItem(0));
 	}
 	
 	@Override


### PR DESCRIPTION
Fixes #316 